### PR TITLE
various open championship fixes

### DIFF
--- a/championship_manager.go
+++ b/championship_manager.go
@@ -106,7 +106,7 @@ func (cm *ChampionshipManager) HandleCreateChampionship(r *http.Request) (champi
 	}
 
 	championship.Name = r.FormValue("ChampionshipName")
-	championship.OpenEntrants = formValueAsInt("ChampionshipOpenEntrants") == 1
+	championship.OpenEntrants = r.FormValue("ChampionshipOpenEntrants") == "on" || r.FormValue("ChampionshipOpenEntrants") == "1"
 
 	previousNumEntrants := 0
 
@@ -296,14 +296,15 @@ func (cm *ChampionshipManager) StartEvent(championshipID string, eventID string)
 		return err
 	}
 
-	if championship.OpenEntrants {
+	// @TODO fixme
+	//if championship.OpenEntrants {
 		event.RaceSetup.LockedEntryList = 0
-	} else {
-		event.RaceSetup.LockedEntryList = 1
-	}
+	//} else {
+	//	event.RaceSetup.LockedEntryList = 1
+	//}
 
+	event.RaceSetup.Cars = strings.Join(championship.ValidCarIDs(), ";")
 	event.RaceSetup.MaxClients = championship.NumEntrants()
-
 	config := ConfigIniDefault
 	config.CurrentRaceConfig = event.RaceSetup
 

--- a/championships.go
+++ b/championships.go
@@ -304,14 +304,18 @@ func (c *ChampionshipClass) Standings(events []*ChampionshipEvent) []*Championsh
 	}
 
 	for _, entrant := range entrants {
+		if entrant.Entrant.Name == "" {
+			continue
+		}
+
 		out = append(out, entrant)
 	}
 
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].Entrant.Name < out[j].Entrant.Name
-	})
+		if out[i].Points == out[j].Points {
+			return out[i].Entrant.Name < out[j].Entrant.Name
+		}
 
-	sort.Slice(out, func(i, j int) bool {
 		return out[i].Points > out[j].Points
 	})
 

--- a/cmd/server-manager/views/pages/championships/view.html
+++ b/cmd/server-manager/views/pages/championships/view.html
@@ -167,7 +167,7 @@
                         <strong>{{ prettify $eventSetup.Track false }} {{ with $eventSetup.TrackLayout }}({{ prettify . true }}){{ end }}</strong>
                     {{ end }}
 
-                    in {{ carList $eventSetup.Cars }}
+                    in {{ carList $championship.ValidCarIDs }}
 
                     <div class="float-right">
                         {{ if $event.Completed }}
@@ -343,17 +343,34 @@
                                 <div class="table-responsive">
                                     <table class="table table-bordered table-striped">
                                         <tr>
+                                            {{ if $championship.IsMultiClass }}
+                                                <th>Class</th>
+                                            {{ end }}
                                             <th>Name</th>
                                             <th>Team</th>
                                             <th>Car</th>
                                         </tr>
 
-                                        {{ range $entrantIndex, $entrant := $championship.AllEntrants }}
-                                            <tr>
-                                                <td>{{ $entrant.Name }}</td>
-                                                <td>{{ $entrant.Team }}</td>
-                                                <td>{{ prettify $entrant.Model true }}</td>
-                                            </tr>
+                                        {{ range $classIndex, $class := $championship.Classes }}
+                                            {{ $entrants := $class.Entrants.AsSlice }}
+
+                                            {{ range $entrantIndex, $entrant := $entrants }}
+                                                <tr {{ if $championship.IsMultiClass }} style="color: white; background: {{ classColor $classIndex }}" {{ end }}>
+                                                    {{ if $championship.IsMultiClass }}
+                                                        {{ if eq $entrantIndex 0 }}
+                                                            <td rowspan="{{ len $entrants }}">{{ $class.Name }}</td>
+                                                        {{ end }}
+                                                    {{ end }}
+
+                                                    {{ if (contains "open slots" $entrant.Name) }}
+                                                        <td colspan="3"><em>{{ $entrant.Name }}</em></td>
+                                                    {{ else }}
+                                                        <td>{{ $entrant.Name }}</td>
+                                                        <td>{{ $entrant.Team }}</td>
+                                                        <td>{{ prettify $entrant.Model true }}</td>
+                                                    {{ end }}
+                                                </tr>
+                                            {{ end }}
                                         {{ end }}
                                     </table>
                                 </div>

--- a/entrylist_ini.go
+++ b/entrylist_ini.go
@@ -3,6 +3,7 @@ package servermanager
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/cj123/ini"
@@ -55,6 +56,37 @@ func (e EntryList) Delete(entrant *Entrant) {
 			return
 		}
 	}
+}
+
+func (e EntryList) AsSlice() []*Entrant {
+	var entrants []*Entrant
+
+	numOpenSlots := 0
+
+	for _, x := range e {
+		if x.Name == "" && x.Team == "" {
+			numOpenSlots++
+			continue
+		}
+
+		entrants = append(entrants, x)
+	}
+
+	sort.Slice(entrants, func(i, j int) bool {
+		if entrants[i].Team == entrants[j].Team {
+			return entrants[i].Name < entrants[j].Name
+		} else {
+			return entrants[i].Team < entrants[j].Team
+		}
+	})
+
+	if numOpenSlots > 0 {
+		entrants = append(entrants, &Entrant{
+			Name: fmt.Sprintf("%d open slots", numOpenSlots),
+		})
+	}
+
+	return entrants
 }
 
 func (e EntryList) Entrants() string {

--- a/fixtures/open-championship-test.json
+++ b/fixtures/open-championship-test.json
@@ -1,0 +1,48512 @@
+[
+  {
+    "Received": "2019-03-02T21:09:08.725197272Z",
+    "EventType": 56,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:09:08.734788884Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:09.946067478Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 38,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": 1,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:25.40962905Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 12,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:25.585222089Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:26.71112532Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 13,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:30.064192793Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:42.196965443Z",
+    "EventType": 58,
+    "Data": 13
+  },
+  {
+    "Received": "2019-03-02T21:09:47.890615937Z",
+    "EventType": 58,
+    "Data": 12
+  },
+  {
+    "Received": "2019-03-02T21:09:49.486432873Z",
+    "EventType": 58,
+    "Data": 14
+  },
+  {
+    "Received": "2019-03-02T21:09:52.948616565Z",
+    "EventType": 58,
+    "Data": 5
+  },
+  {
+    "Received": "2019-03-02T21:11:00.88594501Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:11:31.527147746Z",
+    "EventType": 58,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:11:37.916404489Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 18.542278,
+      "WorldPos": {
+        "X": -5.811005,
+        "Y": 44.792027,
+        "Z": 208.14662
+      },
+      "RelPos": {
+        "X": -0.59411484,
+        "Y": -0.33896056,
+        "Z": 2.3938358
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:11:54.096493651Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 124655,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:12:20.81895975Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 158639,
+      "Cuts": 4,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:12:29.829953127Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 161974,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:12:37.947283571Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 165025,
+      "Cuts": 4,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:13:43.982940723Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 109910,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:13:47.040915262Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 135510,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:01.805953151Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:11.249870916Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 101436,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:18.53858934Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 117731,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:21.102215196Z",
+    "EventType": 58,
+    "Data": 0
+  },
+  {
+    "Received": "2019-03-02T21:14:25.813460758Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 107889,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:15:31.380990763Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 107408,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:15:45.226928009Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 118215,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:15:51.513223175Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100259,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:05.78137251Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 107251,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:14.483770848Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 13.080041,
+      "WorldPos": {
+        "X": -145.16048,
+        "Y": 49.746273,
+        "Z": -99.72126
+      },
+      "RelPos": {
+        "X": -0.26772493,
+        "Y": -0.07525219,
+        "Z": 2.4146066
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:17.701675566Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 111879,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:20.499658072Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 119417,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:12.248350704Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 5,
+      "ImpactSpeed": 24.277805,
+      "WorldPos": {
+        "X": -23.283201,
+        "Y": 45.699642,
+        "Z": 211.3642
+      },
+      "RelPos": {
+        "X": 0.49153316,
+        "Y": -0.08524662,
+        "Z": 2.2436502
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:12.978825768Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 13,
+      "ImpactSpeed": 29.203583,
+      "WorldPos": {
+        "X": -23.369448,
+        "Y": 45.860977,
+        "Z": 211.21024
+      },
+      "RelPos": {
+        "X": -0.9614358,
+        "Y": 0.0034852177,
+        "Z": 1.0738004
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:16.110338115Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 35.68195,
+      "WorldPos": {
+        "X": 39.42399,
+        "Y": 46.70047,
+        "Z": 221.31882
+      },
+      "RelPos": {
+        "X": 0.44601697,
+        "Y": -0.21971717,
+        "Z": 2.5787513
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:31.112092228Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 7.9172673,
+      "WorldPos": {
+        "X": -42.280933,
+        "Y": 48.00404,
+        "Z": 155.38998
+      },
+      "RelPos": {
+        "X": -1.0371108,
+        "Y": 0.2532033,
+        "Z": -1.0039403
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:31.855180359Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100344,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:38.856627968Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 113629,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:03.543626417Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 105840,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:22.089315436Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 136306,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:27.451967565Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 176061,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:57.99758202Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 21.708887,
+      "WorldPos": {
+        "X": 38.94663,
+        "Y": 46.773182,
+        "Z": 227.01897
+      },
+      "RelPos": {
+        "X": -0.753136,
+        "Y": -0.33792946,
+        "Z": 2.3337514
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:19:11.586534351Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 12,
+      "ImpactSpeed": 31.520313,
+      "WorldPos": {
+        "X": -198.21608,
+        "Y": 48.933544,
+        "Z": -720.9078
+      },
+      "RelPos": {
+        "X": 0.96808124,
+        "Y": -0.026201695,
+        "Z": -1.772821
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:19:12.945129978Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 4,
+      "ImpactSpeed": 29.42692,
+      "WorldPos": {
+        "X": -197.96587,
+        "Y": 48.91487,
+        "Z": -720.9955
+      },
+      "RelPos": {
+        "X": -0.7714559,
+        "Y": 0.031207465,
+        "Z": 2.1077843
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:19:55.740574622Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:20:15.382669917Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 107932,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 107932,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:20:20.820527052Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T21:20:21.798630421Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 119701,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 107932,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:20:30.94914187Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:21:51.782855833Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_21_21_QUALIFY.json"
+  },
+  {
+    "Received": "2019-03-02T21:21:51.790896572Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 1,
+      "CurrentSessionIndex": 1,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Race",
+      "Type": 3,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 60000,
+      "AmbientTemp": 26,
+      "RoadTemp": 36,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": -59999,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:12.317883515Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 12,
+      "ImpactSpeed": 39.094646,
+      "WorldPos": {
+        "X": -19.93755,
+        "Y": 53.62102,
+        "Z": -145.9279
+      },
+      "RelPos": {
+        "X": 0.22046942,
+        "Y": 0.028909057,
+        "Z": 2.290286
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:13.325697875Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 13,
+      "ImpactSpeed": 39.90537,
+      "WorldPos": {
+        "X": -19.930222,
+        "Y": 53.621746,
+        "Z": -146.01479
+      },
+      "RelPos": {
+        "X": 0.41375586,
+        "Y": -0.09921125,
+        "Z": -1.911791
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:16.634355568Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 14,
+      "ImpactSpeed": 11.875026,
+      "WorldPos": {
+        "X": -42.159172,
+        "Y": 52.01675,
+        "Z": -121.81439
+      },
+      "RelPos": {
+        "X": -0.92850596,
+        "Y": 0.10343917,
+        "Z": 1.7762165
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:19.573930329Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 4,
+      "ImpactSpeed": 6.9451966,
+      "WorldPos": {
+        "X": -42.188473,
+        "Y": 52.019783,
+        "Z": -121.7854
+      },
+      "RelPos": {
+        "X": 0.8708201,
+        "Y": 0.19308236,
+        "Z": -0.77723074
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:31.639069275Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 13,
+      "ImpactSpeed": 9.566836,
+      "WorldPos": {
+        "X": -214.78761,
+        "Y": 54.420834,
+        "Z": -237.52522
+      },
+      "RelPos": {
+        "X": -0.51635367,
+        "Y": -0.014088921,
+        "Z": -1.9858334
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:32.31934472Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 4,
+      "ImpactSpeed": 10.870226,
+      "WorldPos": {
+        "X": -214.86636,
+        "Y": 54.44567,
+        "Z": -237.40239
+      },
+      "RelPos": {
+        "X": 0.38947755,
+        "Y": 0.03497096,
+        "Z": 2.274087
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:41.8670442Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 110073,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:47.590196034Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 115799,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:48.342537196Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 13,
+      "ImpactSpeed": 14.794508,
+      "WorldPos": {
+        "X": -8.549445,
+        "Y": 65.1321,
+        "Z": -919.04645
+      },
+      "RelPos": {
+        "X": 0.84590185,
+        "Y": 0.12969741,
+        "Z": 1.8989832
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:49.941140373Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 118114,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:51.652789158Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 13,
+      "ImpactSpeed": 27.207985,
+      "WorldPos": {
+        "X": -5.5134254,
+        "Y": 64.94286,
+        "Z": -930.2989
+      },
+      "RelPos": {
+        "X": -0.74266434,
+        "Y": -0.28352273,
+        "Z": 2.323432
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:51.984843782Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 120158,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:51.995005656Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 120161,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:52.336873446Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 4,
+      "ImpactSpeed": 21.892897,
+      "WorldPos": {
+        "X": -5.5154567,
+        "Y": 64.94241,
+        "Z": -929.9571
+      },
+      "RelPos": {
+        "X": 0.84947836,
+        "Y": -0.2639276,
+        "Z": 0.82611984
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:52.342208326Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 12,
+      "ImpactSpeed": 13.813642,
+      "WorldPos": {
+        "X": -8.53854,
+        "Y": 65.14362,
+        "Z": -918.94727
+      },
+      "RelPos": {
+        "X": -0.9053652,
+        "Y": 0.10593543,
+        "Z": 1.1134826
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:56.655350923Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 4,
+      "ImpactSpeed": 35.86649,
+      "WorldPos": {
+        "X": -16.960098,
+        "Y": 64.44094,
+        "Z": -846.7903
+      },
+      "RelPos": {
+        "X": -1.0029845,
+        "Y": 0.11470459,
+        "Z": -1.8480765
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:25:06.321726273Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 134493,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:28.167864284Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 106289,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:34.643463219Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 102688,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:34.691817913Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 107089,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:36.484935701Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 106557,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:41.840029103Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 109870,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:58.429992038Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 112135,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:27:43.235749778Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:07.307795538Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T21:28:10.909115515Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 102764,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:15.52787769Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100882,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:21.038521458Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 106363,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:25.589013499Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 109084,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:27.3620387Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 105544,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:51.292551646Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 112861,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:29:54.366276256Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 103458,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:29:55.819597543Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100301,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:10.973549653Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 109931,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:12.301639178Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 106705,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:13.029891377Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 105675,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:44.240667594Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 112947,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:10.749577416Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 183587,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:37.823635048Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 101999,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:39.800013977Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 105407,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:56.611077093Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 105635,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:59.776719348Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 106721,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:06.219925037Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 113950,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:40.162852974Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:50.440807667Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 126220,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:54.037907605Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 103268,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:59.302912029Z",
+    "EventType": 58,
+    "Data": 2
+  },
+  {
+    "Received": "2019-03-02T21:33:19.523177622Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 101684,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:23.567900834Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 103799,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:40.937569172Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 104290,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:51.568194754Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 105328,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:58.913204593Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 12,
+      "Message": "guys were doing 2 more races"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:59.113532448Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 119343,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 667296,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:12.443906157Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 13,
+      "ImpactSpeed": 12.134497,
+      "WorldPos": {
+        "X": -15.206701,
+        "Y": 62.505207,
+        "Z": -570.23676
+      },
+      "RelPos": {
+        "X": -0.000015616417,
+        "Y": 0.021000223,
+        "Z": 2.3114586
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:17.102091228Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 12,
+      "Message": "rejoin after we're done"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:17.44586817Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 13,
+      "ImpactSpeed": 0.040641572,
+      "WorldPos": {
+        "X": -15.211935,
+        "Y": 62.52244,
+        "Z": -570.2432
+      },
+      "RelPos": {
+        "X": 0.00004470721,
+        "Y": 0.021001603,
+        "Z": 2.3114588
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:18.176682022Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 2,
+      "ImpactSpeed": 17.414568,
+      "WorldPos": {
+        "X": -54.911613,
+        "Y": 50.592987,
+        "Z": -136.20073
+      },
+      "RelPos": {
+        "X": -0.74025893,
+        "Y": -0.2762671,
+        "Z": 2.3216436
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:19.133157669Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 5,
+      "ImpactSpeed": 5.37176,
+      "WorldPos": {
+        "X": -55.406406,
+        "Y": 50.88729,
+        "Z": -136.00749
+      },
+      "RelPos": {
+        "X": -0.7681393,
+        "Y": 0.10559672,
+        "Z": 2.3771882
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:28.178539412Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 13.651996,
+      "WorldPos": {
+        "X": -90.244736,
+        "Y": 51.62519,
+        "Z": -109.31307
+      },
+      "RelPos": {
+        "X": -1.0029707,
+        "Y": 0.11470359,
+        "Z": -1.8480778
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:29.714834669Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 12,
+      "ImpactSpeed": 32.78987,
+      "WorldPos": {
+        "X": -16.758085,
+        "Y": 52.92172,
+        "Z": -114.36712
+      },
+      "RelPos": {
+        "X": 0.55451196,
+        "Y": -0.0042012604,
+        "Z": 2.2253792
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:33.453379987Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 14,
+      "ImpactSpeed": 30.0817,
+      "WorldPos": {
+        "X": -16.459616,
+        "Y": 52.920013,
+        "Z": -114.3293
+      },
+      "RelPos": {
+        "X": 0.5017414,
+        "Y": -0.06312472,
+        "Z": 2.2547133
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:34.713202554Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 12,
+      "ImpactSpeed": 0.94562477,
+      "WorldPos": {
+        "X": -16.974226,
+        "Y": 53.062443,
+        "Z": -119.982956
+      },
+      "RelPos": {
+        "X": 0.82526594,
+        "Y": 0.14744733,
+        "Z": 1.2387986
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:36.885406991Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 102841,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 667296,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 704985,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:38.176716114Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 19.176018,
+      "WorldPos": {
+        "X": -74.927986,
+        "Y": 51.397366,
+        "Z": -78.0888
+      },
+      "RelPos": {
+        "X": 0.7531431,
+        "Y": -0.33792782,
+        "Z": 2.3337522
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:42.451774653Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 12,
+      "ImpactSpeed": 187.16333,
+      "WorldPos": {
+        "X": -22.737139,
+        "Y": 52.814323,
+        "Z": -127.11853
+      },
+      "RelPos": {
+        "X": 0.006248802,
+        "Y": 0.0312353,
+        "Z": 2.249955
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:43.454523451Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 13,
+      "ImpactSpeed": 184.43976,
+      "WorldPos": {
+        "X": -23.148249,
+        "Y": 52.79676,
+        "Z": -127.258995
+      },
+      "RelPos": {
+        "X": 0.7301203,
+        "Y": -0.011246234,
+        "Z": -1.6173282
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:44.714254272Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 45.27735,
+      "WorldPos": {
+        "X": -44.370247,
+        "Y": 52.011753,
+        "Z": -138.8188
+      },
+      "RelPos": {
+        "X": -0.26772702,
+        "Y": -0.07525219,
+        "Z": 2.414605
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:48.179913209Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 53.624336,
+      "WorldPos": {
+        "X": -61.591385,
+        "Y": 50.963203,
+        "Z": -152.75276
+      },
+      "RelPos": {
+        "X": 0.48310763,
+        "Y": 0.07986483,
+        "Z": -2.0333033
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:48.188891233Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 2,
+      "ImpactSpeed": 31.693771,
+      "WorldPos": {
+        "X": -66.4052,
+        "Y": 50.33559,
+        "Z": -153.84962
+      },
+      "RelPos": {
+        "X": -0.90373546,
+        "Y": -0.28399107,
+        "Z": 1.8751855
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:49.151927622Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 5,
+      "ImpactSpeed": 14.6790905,
+      "WorldPos": {
+        "X": -66.41498,
+        "Y": 50.673813,
+        "Z": -153.91437
+      },
+      "RelPos": {
+        "X": -0.41335326,
+        "Y": 0.078642935,
+        "Z": 2.518771
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:53.184277299Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 2,
+      "ImpactSpeed": 8.233119,
+      "WorldPos": {
+        "X": -66.56751,
+        "Y": 50.337013,
+        "Z": -153.97296
+      },
+      "RelPos": {
+        "X": -0.88833475,
+        "Y": -0.26712742,
+        "Z": 1.2227057
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:02.231923377Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 5,
+      "ImpactSpeed": 16.817375,
+      "WorldPos": {
+        "X": -44.250366,
+        "Y": 52.076973,
+        "Z": -100.73863
+      },
+      "RelPos": {
+        "X": -1.0005605,
+        "Y": 0.10572691,
+        "Z": -1.8457379
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:03.181082997Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 1,
+      "ImpactSpeed": 34.61637,
+      "WorldPos": {
+        "X": -44.299366,
+        "Y": 52.05592,
+        "Z": -100.77864
+      },
+      "RelPos": {
+        "X": 0.933162,
+        "Y": 0.11160381,
+        "Z": -1.8497572
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:08.265055924Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 137827,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 667296,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 736471,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 704985,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:26.775001242Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 13,
+      "ImpactSpeed": 219.55276,
+      "WorldPos": {
+        "X": -39.82771,
+        "Y": 51.736614,
+        "Z": -102.340126
+      },
+      "RelPos": {
+        "X": -0.7531392,
+        "Y": -0.3379298,
+        "Z": 2.3337488
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:26.782511838Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 5,
+      "ImpactSpeed": 129.94574,
+      "WorldPos": {
+        "X": -42.05288,
+        "Y": 52.53081,
+        "Z": -83.71655
+      },
+      "RelPos": {
+        "X": -0.94686234,
+        "Y": -0.34824842,
+        "Z": -0.18666974
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:27.455413832Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 4,
+      "ImpactSpeed": 199.72864,
+      "WorldPos": {
+        "X": -39.530144,
+        "Y": 51.750984,
+        "Z": -101.89521
+      },
+      "RelPos": {
+        "X": -0.8575623,
+        "Y": -0.28563473,
+        "Z": 1.1882828
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:28.188898025Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 4,
+      "ImpactSpeed": 110.92213,
+      "WorldPos": {
+        "X": -42.353203,
+        "Y": 52.46694,
+        "Z": -84.10977
+      },
+      "RelPos": {
+        "X": -1.0488393,
+        "Y": 0.36228293,
+        "Z": 1.0086184
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:31.777922442Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 4,
+      "ImpactSpeed": 63.873837,
+      "WorldPos": {
+        "X": -47.30218,
+        "Y": 52.52619,
+        "Z": -35.677143
+      },
+      "RelPos": {
+        "X": -0.90399927,
+        "Y": -0.33399916,
+        "Z": 1.4163027
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:32.455782604Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 13,
+      "ImpactSpeed": 51.10822,
+      "WorldPos": {
+        "X": -64.56666,
+        "Y": 52.30019,
+        "Z": -55.46193
+      },
+      "RelPos": {
+        "X": -0.4754461,
+        "Y": 0.4388718,
+        "Z": -2.061699
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:54.728434728Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 0,
+      "ImpactSpeed": 6.6961966,
+      "WorldPos": {
+        "X": -69.785225,
+        "Y": 50.862392,
+        "Z": -136.48183
+      },
+      "RelPos": {
+        "X": -0.8436349,
+        "Y": 0.093440555,
+        "Z": -0.18212335
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:56.343916512Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 14,
+      "ImpactSpeed": 6.637684,
+      "WorldPos": {
+        "X": -69.78588,
+        "Y": 50.86696,
+        "Z": -136.48225
+      },
+      "RelPos": {
+        "X": 0.7859641,
+        "Y": 0.11970091,
+        "Z": 2.4330487
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:58.196176483Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 27.822073,
+      "WorldPos": {
+        "X": -151.89566,
+        "Y": 54.182297,
+        "Z": -233.62479
+      },
+      "RelPos": {
+        "X": 0.98289543,
+        "Y": 0.11470422,
+        "Z": -1.848078
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:59.729729538Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 16.162987,
+      "WorldPos": {
+        "X": -61.42354,
+        "Y": 50.71328,
+        "Z": -152.38422
+      },
+      "RelPos": {
+        "X": -0.5547012,
+        "Y": -0.0042031445,
+        "Z": 2.2253718
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:09.729883725Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 4,
+      "ImpactSpeed": 2.6417935,
+      "WorldPos": {
+        "X": -63.21272,
+        "Y": 50.654316,
+        "Z": -141.74022
+      },
+      "RelPos": {
+        "X": 0.82790667,
+        "Y": 0.026703224,
+        "Z": -1.2146415
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:11.347366397Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 10.097206,
+      "WorldPos": {
+        "X": -71.57716,
+        "Y": 50.56206,
+        "Z": -171.44257
+      },
+      "RelPos": {
+        "X": 0.4050244,
+        "Y": -0.26062438,
+        "Z": 2.598421
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:11.78777821Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 14,
+      "ImpactSpeed": 2.6076248,
+      "WorldPos": {
+        "X": -63.210712,
+        "Y": 50.668953,
+        "Z": -141.75197
+      },
+      "RelPos": {
+        "X": -1.0112256,
+        "Y": -0.003489851,
+        "Z": -1.0055783
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:25.977489149Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 12,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:26.785353183Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 4,
+      "ImpactSpeed": 15.688271,
+      "WorldPos": {
+        "X": -73.63849,
+        "Y": 50.600716,
+        "Z": -175.89908
+      },
+      "RelPos": {
+        "X": 0.5762212,
+        "Y": -0.33907554,
+        "Z": 2.4005952
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:26.915915616Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:27.807126494Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 13,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:28.598028354Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:29.313277776Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:33.270198718Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:35.032681175Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:40.387347494Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:40.400084037Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_21_36_RACE.json"
+  },
+  {
+    "Received": "2019-03-02T21:36:40.401223435Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 25,
+      "RoadTemp": 36,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:12.042904371Z",
+    "EventType": 56,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:37:12.052989971Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:13.263909557Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 36,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:21.088246367Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:24.317108463Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 7,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:25.999885344Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:27.97710064Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:31.866812414Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 19,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:37.576238697Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 8,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:37.999876104Z",
+    "EventType": 58,
+    "Data": 5
+  },
+  {
+    "Received": "2019-03-02T21:37:40.877808024Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:45.758348344Z",
+    "EventType": 58,
+    "Data": 7
+  },
+  {
+    "Received": "2019-03-02T21:37:51.251522766Z",
+    "EventType": 58,
+    "Data": 19
+  },
+  {
+    "Received": "2019-03-02T21:37:51.865407588Z",
+    "EventType": 58,
+    "Data": 8
+  },
+  {
+    "Received": "2019-03-02T21:37:51.945899126Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T21:37:53.022582709Z",
+    "EventType": 58,
+    "Data": 2
+  },
+  {
+    "Received": "2019-03-02T21:37:57.173376601Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 6,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:11.539169666Z",
+    "EventType": 58,
+    "Data": 0
+  },
+  {
+    "Received": "2019-03-02T21:38:17.606616501Z",
+    "EventType": 58,
+    "Data": 6
+  },
+  {
+    "Received": "2019-03-02T21:38:20.457285067Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 19,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:22.999182262Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 3.4596066,
+      "WorldPos": {
+        "X": -82.11017,
+        "Y": 5.2242184,
+        "Z": 372.9922
+      },
+      "RelPos": {
+        "X": 1.06182,
+        "Y": 0.42115015,
+        "Z": 0.78120726
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:39.21786618Z",
+    "EventType": 58,
+    "Data": 19
+  },
+  {
+    "Received": "2019-03-02T21:38:47.455807272Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 6,
+      "ImpactSpeed": 18.330818,
+      "WorldPos": {
+        "X": -85.2096,
+        "Y": 5.2810855,
+        "Z": 354.99478
+      },
+      "RelPos": {
+        "X": -0.9588042,
+        "Y": -0.119409926,
+        "Z": -1.0309438
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:50.191630362Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 72374,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:15.845102598Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 90131,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:19.965825514Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 88125,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:22.799399419Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 89754,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:31.866791633Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 2,
+      "ImpactSpeed": 23.515629,
+      "WorldPos": {
+        "X": -88.74069,
+        "Y": 4.919533,
+        "Z": 382.33865
+      },
+      "RelPos": {
+        "X": -0.27980423,
+        "Y": -0.10858263,
+        "Z": -1.9046298
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:32.46578278Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 6,
+      "ImpactSpeed": 46.403378,
+      "WorldPos": {
+        "X": 671.3677,
+        "Y": 2.49896,
+        "Z": 68.04241
+      },
+      "RelPos": {
+        "X": -0.960501,
+        "Y": -0.2639836,
+        "Z": -1.0496056
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:33.012572911Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 8,
+      "ImpactSpeed": 31.24352,
+      "WorldPos": {
+        "X": -88.741135,
+        "Y": 4.9266987,
+        "Z": 382.29172
+      },
+      "RelPos": {
+        "X": -0.40420747,
+        "Y": -0.13817638,
+        "Z": 2.5619392
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:36.467611533Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 6,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:37.704868147Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 86194,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:44.769792181Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 112866,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:48.000320297Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:50.75586255Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 60545,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:58.118103566Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:02.780953742Z",
+    "EventType": 58,
+    "Data": 14
+  },
+  {
+    "Received": "2019-03-02T21:40:12.8362812Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 44.08058,
+      "WorldPos": {
+        "X": -252.87401,
+        "Y": 7.892081,
+        "Z": 28.513966
+      },
+      "RelPos": {
+        "X": 0.7531396,
+        "Y": -0.25777528,
+        "Z": 2.4668858
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:14.057404003Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58197,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:16.961706846Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 97755,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:19.682293816Z",
+    "EventType": 58,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:40:29.744855011Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:35.164444927Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 75167,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:36.537248177Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 53.941162,
+      "WorldPos": {
+        "X": 639.5377,
+        "Y": -6.4124155,
+        "Z": 155.32301
+      },
+      "RelPos": {
+        "X": 0.40504396,
+        "Y": -0.3401828,
+        "Z": 2.4652991
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:36.625941453Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 15,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:41.804368845Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:41.925393449Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 8.076889,
+      "WorldPos": {
+        "X": 550.0641,
+        "Y": -8.876603,
+        "Z": 224.56955
+      },
+      "RelPos": {
+        "X": 1.0618303,
+        "Y": 0.36228234,
+        "Z": 1.0086217
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:43.029374671Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 8.968531,
+      "WorldPos": {
+        "X": 550.2631,
+        "Y": -8.875664,
+        "Z": 224.5125
+      },
+      "RelPos": {
+        "X": -1.0273305,
+        "Y": 0.34762108,
+        "Z": 0.64361054
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:46.748824939Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 61987,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:47.067101882Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 84307,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:54.82806554Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 77122,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:56.811447454Z",
+    "EventType": 58,
+    "Data": 15
+  },
+  {
+    "Received": "2019-03-02T21:41:01.227480518Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "01_racing_red",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:13.129828498Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59089,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:13.790468015Z",
+    "EventType": 58,
+    "Data": 9
+  },
+  {
+    "Received": "2019-03-02T21:41:19.273791578Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62297,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:21.54335546Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 19.087461,
+      "WorldPos": {
+        "X": -253.11035,
+        "Y": 8.347797,
+        "Z": 28.379944
+      },
+      "RelPos": {
+        "X": -1.002975,
+        "Y": 0.11470608,
+        "Z": -1.8480747
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:37.924142682Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 62777,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:40.06565081Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 97444,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:47.815155756Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 60756,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:50.234303894Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 63447,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:11.081877963Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 76245,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:12.171722336Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59023,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:22.052562909Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62804,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:34.688202542Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 81073,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:40.417845412Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60360,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:42.44191057Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "01_racing_red",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:44.492010146Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 66585,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:49.384395917Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 61564,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:50.734536155Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 60538,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:57.803499333Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 16,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:10.142847533Z",
+    "EventType": 58,
+    "Data": 16
+  },
+  {
+    "Received": "2019-03-02T21:43:10.725014144Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58577,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:13.192690034Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 62081,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:26.971947748Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 64910,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:50.360853631Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 65871,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:55.140272378Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64400,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:55.773105746Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 2,
+      "ImpactSpeed": 61.071697,
+      "WorldPos": {
+        "X": 631.898,
+        "Y": 3.1410034,
+        "Z": 37.97196
+      },
+      "RelPos": {
+        "X": 0.9197418,
+        "Y": -0.25077108,
+        "Z": -1.2273545
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:58.075047209Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 7,
+      "ImpactSpeed": 53.444782,
+      "WorldPos": {
+        "X": 631.8672,
+        "Y": 3.1153967,
+        "Z": 38.224266
+      },
+      "RelPos": {
+        "X": 0.0053220987,
+        "Y": -0.25576723,
+        "Z": 2.633796
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:14.802048337Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 64087,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:16.257862202Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 86847,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:17.594823242Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 64433,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:21.755704201Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 204899,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:21.964037832Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 70.24515,
+      "WorldPos": {
+        "X": -262.906,
+        "Y": 8.518117,
+        "Z": 22.781559
+      },
+      "RelPos": {
+        "X": 0.40501606,
+        "Y": -0.34018025,
+        "Z": 2.4652996
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:28.846121225Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 61859,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:39.264262197Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 4.6203675,
+      "WorldPos": {
+        "X": -83.12829,
+        "Y": 5.112513,
+        "Z": 371.9643
+      },
+      "RelPos": {
+        "X": 0.6354965,
+        "Y": 0.2201055,
+        "Z": -1.4963211
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:41.598870122Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 91621,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:51.019823924Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 60655,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:51.972614169Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 29.39239,
+      "WorldPos": {
+        "X": 67.01412,
+        "Y": 3.1010642,
+        "Z": -20.582636
+      },
+      "RelPos": {
+        "X": -0.03949946,
+        "Y": -0.115679756,
+        "Z": -2.0003524
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:53.080706406Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 26.648136,
+      "WorldPos": {
+        "X": 67.16325,
+        "Y": 3.049012,
+        "Z": -20.813665
+      },
+      "RelPos": {
+        "X": -0.23387921,
+        "Y": -0.06850241,
+        "Z": 2.5451326
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:05.94307614Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 145516,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:19.270203316Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 7.2500153,
+      "WorldPos": {
+        "X": 141.04803,
+        "Y": -11.764014,
+        "Z": 333.6731
+      },
+      "RelPos": {
+        "X": 0.81933147,
+        "Y": 0.2769497,
+        "Z": 1.2484288
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:20.267405448Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 65458,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:21.593280586Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 28.949938,
+      "WorldPos": {
+        "X": 528.66394,
+        "Y": -9.399206,
+        "Z": 248.89313
+      },
+      "RelPos": {
+        "X": -0.40499365,
+        "Y": -0.34018284,
+        "Z": 2.4653058
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:23.334978124Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 67099,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:29.272843555Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 4.3917828,
+      "WorldPos": {
+        "X": 61.724037,
+        "Y": -7.701953,
+        "Z": 352.9893
+      },
+      "RelPos": {
+        "X": -0.76444626,
+        "Y": 0.27832356,
+        "Z": 1.8490113
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:37.369323134Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 79792,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:42.379294662Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 107237,
+      "Cuts": 5,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:42.640469459Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 61057,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:52.33667028Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61322,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:06.530822678Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60567,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:11.986567684Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 40.87872,
+      "WorldPos": {
+        "X": -256.5494,
+        "Y": 8.090948,
+        "Z": 26.381516
+      },
+      "RelPos": {
+        "X": 0.7531419,
+        "Y": -0.33792984,
+        "Z": 2.3337407
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:18.557376359Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58299,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:23.250839151Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 59878,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:42.653462814Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 65278,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:47.466646247Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 64823,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:49.453577914Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 140614,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:54.71142528Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 62373,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:56.235453151Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 73848,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:59.291423305Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 15.448443,
+      "WorldPos": {
+        "X": -76.54756,
+        "Y": 3.9989588,
+        "Z": 383.15363
+      },
+      "RelPos": {
+        "X": -0.2677287,
+        "Y": -0.075251,
+        "Z": 2.414592
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:07.010705399Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60516,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:30.70315599Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 189021,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 189021,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:46.515471681Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63815,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 189021,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:57.37479123Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 61137,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61137,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 189021,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:01.633585484Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 6.5178733,
+      "WorldPos": {
+        "X": -111.53546,
+        "Y": 7.343877,
+        "Z": 430.43973
+      },
+      "RelPos": {
+        "X": -0.78594345,
+        "Y": 0.039387245,
+        "Z": 2.2981675
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:02.687605661Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 54.973114,
+      "WorldPos": {
+        "X": 545.8572,
+        "Y": -8.688885,
+        "Z": 245.48264
+      },
+      "RelPos": {
+        "X": 0.7771702,
+        "Y": -0.045661706,
+        "Z": -1.382614
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:07.691151235Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 13.51755,
+      "WorldPos": {
+        "X": 441.8475,
+        "Y": -10.812998,
+        "Z": 248.50237
+      },
+      "RelPos": {
+        "X": 0.635494,
+        "Y": 0.22010534,
+        "Z": -1.496328
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:11.623086952Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 8,
+      "ImpactSpeed": 102.47527,
+      "WorldPos": {
+        "X": -75.59137,
+        "Y": 3.873283,
+        "Z": 405.27777
+      },
+      "RelPos": {
+        "X": 0.93286204,
+        "Y": 0.0018701442,
+        "Z": 1.7754714
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:11.632012452Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 33.73157,
+      "WorldPos": {
+        "X": -61.859505,
+        "Y": 2.915883,
+        "Z": 416.17844
+      },
+      "RelPos": {
+        "X": -0.0000042915344,
+        "Y": -0.3396025,
+        "Z": 2.5021923
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:11.956655004Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 0,
+      "ImpactSpeed": 111.832794,
+      "WorldPos": {
+        "X": -75.494484,
+        "Y": 3.6153605,
+        "Z": 405.2506
+      },
+      "RelPos": {
+        "X": 0.48650712,
+        "Y": -0.18413615,
+        "Z": 2.2361999
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:12.693510146Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 1.229967,
+      "WorldPos": {
+        "X": 441.54178,
+        "Y": -11.340387,
+        "Z": 248.60202
+      },
+      "RelPos": {
+        "X": 0.293173,
+        "Y": -0.3017311,
+        "Z": -1.4648188
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:15.822303853Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 22.237503,
+      "WorldPos": {
+        "X": 597.1134,
+        "Y": -8.620743,
+        "Z": 192.36179
+      },
+      "RelPos": {
+        "X": 0.5137629,
+        "Y": 0.03942673,
+        "Z": 2.2621512
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:30.017572922Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 16,
+      "OtherCarID": 14,
+      "ImpactSpeed": 72.806984,
+      "WorldPos": {
+        "X": 51.212345,
+        "Y": -6.94435,
+        "Z": 366.27838
+      },
+      "RelPos": {
+        "X": 0.38887668,
+        "Y": -0.13965902,
+        "Z": 2.298734
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:32.691892556Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 16,
+      "ImpactSpeed": 91.31936,
+      "WorldPos": {
+        "X": 51.064587,
+        "Y": -6.870232,
+        "Z": 366.06497
+      },
+      "RelPos": {
+        "X": 0.12476914,
+        "Y": -0.16057822,
+        "Z": -1.3349594
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:11.171456455Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "hi"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:18.94285641Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "sup"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:28.46085895Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "missmatch with mods god noes why"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:31.720873494Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "r u from discord"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:38.047937297Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "it was update4d today"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:45.973302403Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 0,
+      "Message": "no. im from niferia"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:49.465529433Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "ohhh ok"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:55.416685396Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_21_49_QUALIFY.json"
+  },
+  {
+    "Received": "2019-03-02T21:49:55.441734491Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 1,
+      "CurrentSessionIndex": 1,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Race",
+      "Type": 3,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 60000,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": -59999,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:57.340095184Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 0,
+      "Message": "wakanda forever"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:51:26.764736308Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 60.151325,
+      "WorldPos": {
+        "X": -261.67056,
+        "Y": 8.919584,
+        "Z": 23.479906
+      },
+      "RelPos": {
+        "X": 0.8929572,
+        "Y": 0.19191818,
+        "Z": 1.7670182
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:51:30.055123019Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 16,
+      "OtherCarID": 0,
+      "ImpactSpeed": 0.7579006,
+      "WorldPos": {
+        "X": -189.51445,
+        "Y": 3.5808847,
+        "Z": 42.479992
+      },
+      "RelPos": {
+        "X": 0.8338914,
+        "Y": 0.03970459,
+        "Z": -1.1850265
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:51:31.67389167Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 16,
+      "ImpactSpeed": 7.2466393,
+      "WorldPos": {
+        "X": -189.5225,
+        "Y": 3.5618987,
+        "Z": 42.53072
+      },
+      "RelPos": {
+        "X": -0.788803,
+        "Y": -0.051797982,
+        "Z": 2.2685122
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:01.74010634Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 66304,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:02.363781653Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 66938,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:03.675724455Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 68157,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:05.829476682Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 70399,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:05.977352238Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 70457,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:06.860480958Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 71391,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:08.457320299Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 73011,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:17.630949935Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 82204,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:17.840056083Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 82384,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:22.058982045Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 19.164434,
+      "WorldPos": {
+        "X": -274.1923,
+        "Y": 7.5828037,
+        "Z": 113.08818
+      },
+      "RelPos": {
+        "X": 0.8488104,
+        "Y": -0.18180327,
+        "Z": 2.0543165
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:23.177133578Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 19.685852,
+      "WorldPos": {
+        "X": -274.1873,
+        "Y": 7.8141065,
+        "Z": 113.03572
+      },
+      "RelPos": {
+        "X": -0.98529994,
+        "Y": -0.074490674,
+        "Z": -1.2714918
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:27.065942203Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 19.95239,
+      "WorldPos": {
+        "X": -269.58817,
+        "Y": 9.283741,
+        "Z": 23.860826
+      },
+      "RelPos": {
+        "X": -1.0029825,
+        "Y": 0.11470597,
+        "Z": -1.8480824
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:27.080593643Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 5.5364323,
+      "WorldPos": {
+        "X": -268.29575,
+        "Y": 9.324921,
+        "Z": 19.706554
+      },
+      "RelPos": {
+        "X": 0.9828891,
+        "Y": 0.11470581,
+        "Z": -1.8480811
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:28.176200387Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 24.19631,
+      "WorldPos": {
+        "X": -269.55066,
+        "Y": 9.279741,
+        "Z": 23.914267
+      },
+      "RelPos": {
+        "X": -0.9584526,
+        "Y": 0.07306049,
+        "Z": -1.407486
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:28.182408274Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 24.952705,
+      "WorldPos": {
+        "X": -267.67563,
+        "Y": 9.2146,
+        "Z": 20.068031
+      },
+      "RelPos": {
+        "X": 0.78597134,
+        "Y": 0.11969936,
+        "Z": 2.4330282
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:34.362849203Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 8.50892,
+      "WorldPos": {
+        "X": -260.52338,
+        "Y": 7.8806734,
+        "Z": 60.956448
+      },
+      "RelPos": {
+        "X": -0.26773274,
+        "Y": -0.07525164,
+        "Z": 2.4145794
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:44.36651367Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 19,
+      "OtherCarID": 0,
+      "ImpactSpeed": 11.218829,
+      "WorldPos": {
+        "X": -192.88681,
+        "Y": 3.9854534,
+        "Z": 39.799446
+      },
+      "RelPos": {
+        "X": 0.8175962,
+        "Y": 0.2386778,
+        "Z": 1.2449865
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:46.680055822Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 19,
+      "ImpactSpeed": 26.766272,
+      "WorldPos": {
+        "X": -163.28918,
+        "Y": 1.9320467,
+        "Z": 66.846756
+      },
+      "RelPos": {
+        "X": -0.98438007,
+        "Y": 0.15120523,
+        "Z": 0.4913641
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:49.365443729Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 19,
+      "OtherCarID": 0,
+      "ImpactSpeed": 24.419199,
+      "WorldPos": {
+        "X": -163.20607,
+        "Y": 1.934947,
+        "Z": 66.939926
+      },
+      "RelPos": {
+        "X": 0.76426,
+        "Y": 0.27832302,
+        "Z": 1.8490052
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:03.071984987Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59391,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:04.189151987Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58339,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:07.24471117Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60398,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:08.62294695Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 62661,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:10.492109795Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 68114,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:10.50424228Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 68739,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:20.01990109Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 62204,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:24.044892918Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 66416,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:25.718117562Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 77255,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:51.690047221Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 37.83473,
+      "WorldPos": {
+        "X": -250.04205,
+        "Y": 8.087604,
+        "Z": 30.118235
+      },
+      "RelPos": {
+        "X": -0.7859706,
+        "Y": 0.03938737,
+        "Z": 2.2981796
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:02.559200888Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58389,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:04.476701276Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60920,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:07.405966566Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60181,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:10.513981825Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 60037,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:15.798733457Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 67184,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:21.700708827Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61689,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:28.172474502Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62476,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:29.568954199Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 79092,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:39.885515341Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 75827,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:00.704418706Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58131,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:03.811625266Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59844,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:09.84144072Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59307,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:16.705591469Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 8.983585,
+      "WorldPos": {
+        "X": 1.5827987,
+        "Y": 3.935679,
+        "Z": -22.583578
+      },
+      "RelPos": {
+        "X": 0.75313985,
+        "Y": -0.3379301,
+        "Z": 2.33375
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:18.49448178Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 62633,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:20.271468404Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 72865,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:22.843310035Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61146,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:30.237607704Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62051,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:37.319027443Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 67756,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:59.276799104Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58589,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:00.146032638Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 80255,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:03.795576072Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59948,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:09.610241591Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59769,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:11.818055088Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 44.64223,
+      "WorldPos": {
+        "X": -102.78479,
+        "Y": 6.3716707,
+        "Z": 317.2829
+      },
+      "RelPos": {
+        "X": -0.77143013,
+        "Y": 0.031209026,
+        "Z": 2.107809
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:19.206319049Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 60752,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:20.157392727Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 59887,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:22.817846456Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 59975,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:32.289218351Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62067,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:43.5650946Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 66227,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:03.819749225Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63704,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:04.128424293Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60330,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:05.378400446Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 66108,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:09.664985948Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 60052,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:20.067192169Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 60865,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:20.525883889Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60351,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:22.71269897Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 59889,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:31.989244145Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 15,
+      "OtherCarID": 16,
+      "ImpactSpeed": 23.996357,
+      "WorldPos": {
+        "X": -98.60322,
+        "Y": 5.5790386,
+        "Z": 373.3994
+      },
+      "RelPos": {
+        "X": -0.7881047,
+        "Y": -0.11047131,
+        "Z": -1.2807758
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:35.071227011Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62783,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:36.987730357Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 15,
+      "ImpactSpeed": 22.088165,
+      "WorldPos": {
+        "X": -106.250145,
+        "Y": 6.444098,
+        "Z": 310.7157
+      },
+      "RelPos": {
+        "X": 0.8397838,
+        "Y": 0.04364412,
+        "Z": -1.1753184
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:53.89618219Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 70333,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:04.073006584Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59993,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:04.690772841Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59309,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:09.097583008Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59450,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:17.498999987Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 73663,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:26.479251856Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 63773,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:41.174938249Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 81109,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:41.263400336Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 80739,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:42.957168792Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 67871,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:00.207601805Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 66335,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:03.695462702Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58989,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:04.161056153Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60078,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:08.511933584Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59412,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:20.27931446Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 62789,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:27.812218621Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61338,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:28.26323115Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 11.4801035,
+      "WorldPos": {
+        "X": -221.82883,
+        "Y": 6.7115088,
+        "Z": 18.638765
+      },
+      "RelPos": {
+        "X": -0.7531461,
+        "Y": -0.25777435,
+        "Z": 2.4668899
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:45.577011506Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62625,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:46.273549864Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 65120,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:48.316657765Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 67067,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:02.719701578Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59026,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:07.962282837Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59463,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:08.652992347Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 64493,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:22.637743866Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 82415,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:23.762591644Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63488,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:27.872816655Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 60043,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:32.148443975Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 52.47059,
+      "WorldPos": {
+        "X": -249.9529,
+        "Y": 8.051628,
+        "Z": 30.170914
+      },
+      "RelPos": {
+        "X": 0.80535245,
+        "Y": 0.048095927,
+        "Z": 2.2271874
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:34.467317628Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 32.512924,
+      "WorldPos": {
+        "X": 607.6385,
+        "Y": 1.8698356,
+        "Z": 57.80841
+      },
+      "RelPos": {
+        "X": -0.777323,
+        "Y": -0.04566363,
+        "Z": -1.3826513
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:39.46235017Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 30.403107,
+      "WorldPos": {
+        "X": 607.95355,
+        "Y": 1.8318199,
+        "Z": 61.93704
+      },
+      "RelPos": {
+        "X": -0.7644508,
+        "Y": 0.2783232,
+        "Z": 1.8490088
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:46.770805439Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 19.93299,
+      "WorldPos": {
+        "X": -246.27867,
+        "Y": 7.675321,
+        "Z": 46.942017
+      },
+      "RelPos": {
+        "X": -1.0029705,
+        "Y": 0.114706226,
+        "Z": -1.8480825
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:48.770518051Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60446,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:53.463881216Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 67842,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:56.460425026Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 70184,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:01.661144608Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58960,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:02.103290804Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 29.964302,
+      "WorldPos": {
+        "X": -33.53648,
+        "Y": 2.3873506,
+        "Z": 30.821192
+      },
+      "RelPos": {
+        "X": 0.51375085,
+        "Y": 0.039426386,
+        "Z": 2.262146
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:07.155829268Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 47.52934,
+      "WorldPos": {
+        "X": 554.79584,
+        "Y": -9.634177,
+        "Z": 213.61081
+      },
+      "RelPos": {
+        "X": -0.40499622,
+        "Y": -0.3401801,
+        "Z": 2.4653006
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:12.052973322Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 15,
+      "ImpactSpeed": 25.797651,
+      "WorldPos": {
+        "X": -256.84503,
+        "Y": 8.401481,
+        "Z": 26.218225
+      },
+      "RelPos": {
+        "X": 0.7771783,
+        "Y": -0.045663007,
+        "Z": -1.382657
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:16.869640945Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 3.7860413,
+      "WorldPos": {
+        "X": -118.90106,
+        "Y": 8.079986,
+        "Z": 432.57657
+      },
+      "RelPos": {
+        "X": 0.8929633,
+        "Y": 0.1919197,
+        "Z": 1.7670436
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:17.032665561Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 15,
+      "ImpactSpeed": 19.565325,
+      "WorldPos": {
+        "X": -241.82867,
+        "Y": 7.649433,
+        "Z": 26.85688
+      },
+      "RelPos": {
+        "X": 0.5545147,
+        "Y": -0.00420139,
+        "Z": 2.2253757
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:17.219218873Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 69263,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:18.099374392Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 69464,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:21.873106228Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 5.8333716,
+      "WorldPos": {
+        "X": -120.49291,
+        "Y": 8.195454,
+        "Z": 433.0098
+      },
+      "RelPos": {
+        "X": 0.8926878,
+        "Y": 0.19192792,
+        "Z": 1.7669395
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:23.949881273Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 61324,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:27.29798827Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63516,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.785676927Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 14,
+      "ImpactSpeed": 208.04527,
+      "WorldPos": {
+        "X": -125.08344,
+        "Y": 7.97045,
+        "Z": 422.88522
+      },
+      "RelPos": {
+        "X": 0.5726485,
+        "Y": -0.17318496,
+        "Z": 2.3892708
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.78988064Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 109.596054,
+      "WorldPos": {
+        "X": -155.75008,
+        "Y": 10.691232,
+        "Z": 428.7087
+      },
+      "RelPos": {
+        "X": -0.48311728,
+        "Y": 0.079864554,
+        "Z": -2.0332959
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.802121132Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 2,
+      "ImpactSpeed": 57.33579,
+      "WorldPos": {
+        "X": -155.83632,
+        "Y": 10.9676485,
+        "Z": 437.2277
+      },
+      "RelPos": {
+        "X": 1.0044783,
+        "Y": 0.2864175,
+        "Z": -0.66210705
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.880007679Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 14,
+      "ImpactSpeed": 33.481716,
+      "WorldPos": {
+        "X": -153.3954,
+        "Y": 10.366754,
+        "Z": 436.4096
+      },
+      "RelPos": {
+        "X": 0.8063765,
+        "Y": -0.12922801,
+        "Z": 1.9518377
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.89242632Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 29.874668,
+      "WorldPos": {
+        "X": -157.91148,
+        "Y": 11.191903,
+        "Z": 433.64728
+      },
+      "RelPos": {
+        "X": -0.47544488,
+        "Y": 0.43887338,
+        "Z": -2.0616958
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.902091511Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 2,
+      "ImpactSpeed": 20.628216,
+      "WorldPos": {
+        "X": -155.02846,
+        "Y": 10.634883,
+        "Z": 437.40915
+      },
+      "RelPos": {
+        "X": -0.75858414,
+        "Y": -0.0334175,
+        "Z": 2.0977073
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:37.867354785Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 7,
+      "ImpactSpeed": 22.242691,
+      "WorldPos": {
+        "X": -153.26666,
+        "Y": 10.334529,
+        "Z": 436.27655
+      },
+      "RelPos": {
+        "X": -0.4491886,
+        "Y": -0.03031699,
+        "Z": 2.2949402
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:37.879778393Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 0,
+      "ImpactSpeed": 212.07497,
+      "WorldPos": {
+        "X": -125.39172,
+        "Y": 7.9315853,
+        "Z": 422.70438
+      },
+      "RelPos": {
+        "X": -0.79995793,
+        "Y": -0.18203239,
+        "Z": -1.1682969
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:38.293510081Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 20.820036,
+      "WorldPos": {
+        "X": -154.84471,
+        "Y": 10.345164,
+        "Z": 441.95435
+      },
+      "RelPos": {
+        "X": 0.40502143,
+        "Y": -0.26062307,
+        "Z": 2.5984004
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:38.309578101Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 0,
+      "ImpactSpeed": 55.3255,
+      "WorldPos": {
+        "X": -155.88245,
+        "Y": 10.784434,
+        "Z": 437.27927
+      },
+      "RelPos": {
+        "X": -0.8507536,
+        "Y": 0.117051594,
+        "Z": -1.7332517
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:38.321211841Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 7,
+      "ImpactSpeed": 17.353468,
+      "WorldPos": {
+        "X": -154.8284,
+        "Y": 10.614723,
+        "Z": 437.38107
+      },
+      "RelPos": {
+        "X": 0.27431127,
+        "Y": 0.009841822,
+        "Z": -1.8450598
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:39.005806337Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 71141,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.780944826Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 2,
+      "ImpactSpeed": 3.9263742,
+      "WorldPos": {
+        "X": -156.04315,
+        "Y": 10.846758,
+        "Z": 438.73694
+      },
+      "RelPos": {
+        "X": 0.98290235,
+        "Y": 0.11470618,
+        "Z": -1.8480711
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.790047416Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 7,
+      "ImpactSpeed": 13.8442955,
+      "WorldPos": {
+        "X": -155.96997,
+        "Y": 10.781507,
+        "Z": 436.20627
+      },
+      "RelPos": {
+        "X": 0.4831252,
+        "Y": 0.079863995,
+        "Z": -2.0332792
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.880294582Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 14,
+      "ImpactSpeed": 0.012167076,
+      "WorldPos": {
+        "X": -152.37148,
+        "Y": 10.4214735,
+        "Z": 436.88293
+      },
+      "RelPos": {
+        "X": -0.14010495,
+        "Y": 0.026450079,
+        "Z": 2.2931013
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.889876058Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 0,
+      "ImpactSpeed": 12.510661,
+      "WorldPos": {
+        "X": -155.9379,
+        "Y": 10.788488,
+        "Z": 436.2193
+      },
+      "RelPos": {
+        "X": -0.9439887,
+        "Y": 0.120106846,
+        "Z": -0.83350706
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:42.852132175Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 7,
+      "ImpactSpeed": 4.888293,
+      "WorldPos": {
+        "X": -152.21939,
+        "Y": 10.089093,
+        "Z": 436.4476
+      },
+      "RelPos": {
+        "X": -0.8429633,
+        "Y": -0.25584397,
+        "Z": 0.76378095
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:43.293749418Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 0,
+      "ImpactSpeed": 6.6065187,
+      "WorldPos": {
+        "X": -155.85612,
+        "Y": 10.839186,
+        "Z": 437.39645
+      },
+      "RelPos": {
+        "X": -0.85524315,
+        "Y": 0.10990144,
+        "Z": -1.8228945
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.780603703Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 7.0252166,
+      "WorldPos": {
+        "X": -154.43533,
+        "Y": 10.270536,
+        "Z": 426.14966
+      },
+      "RelPos": {
+        "X": -1.0029786,
+        "Y": -0.2807202,
+        "Z": -1.7505336
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.789048977Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 7,
+      "ImpactSpeed": 4.07245,
+      "WorldPos": {
+        "X": -154.73566,
+        "Y": 10.885412,
+        "Z": 433.07996
+      },
+      "RelPos": {
+        "X": 1.0476648,
+        "Y": 0.35515678,
+        "Z": 0.65042937
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.88063293Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 0,
+      "ImpactSpeed": 10.610559,
+      "WorldPos": {
+        "X": -154.95769,
+        "Y": 10.717422,
+        "Z": 433.83246
+      },
+      "RelPos": {
+        "X": -0.9346254,
+        "Y": 0.15596303,
+        "Z": -1.2384216
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.893809153Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 8,
+      "ImpactSpeed": 152.5637,
+      "WorldPos": {
+        "X": -152.4925,
+        "Y": 10.206379,
+        "Z": 436.09396
+      },
+      "RelPos": {
+        "X": 0.87033576,
+        "Y": -0.18769015,
+        "Z": 1.6011555
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.904431936Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 2,
+      "ImpactSpeed": 65.09792,
+      "WorldPos": {
+        "X": -157.17609,
+        "Y": 11.171963,
+        "Z": 437.84497
+      },
+      "RelPos": {
+        "X": -0.42879808,
+        "Y": 0.29894054,
+        "Z": -1.7982403
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.917077308Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 66.07118,
+      "WorldPos": {
+        "X": -159.44006,
+        "Y": 10.497653,
+        "Z": 436.9085
+      },
+      "RelPos": {
+        "X": 0.89857495,
+        "Y": -0.22570662,
+        "Z": -1.373745
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.129751178Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 1,
+      "ImpactSpeed": 177.34915,
+      "WorldPos": {
+        "X": -136.95294,
+        "Y": 9.23824,
+        "Z": 433.24948
+      },
+      "RelPos": {
+        "X": 0.51375073,
+        "Y": 0.039425522,
+        "Z": 2.262154
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.146057375Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 7,
+      "ImpactSpeed": 121.54132,
+      "WorldPos": {
+        "X": -153.20627,
+        "Y": 10.558446,
+        "Z": 436.44324
+      },
+      "RelPos": {
+        "X": -0.76110685,
+        "Y": -0.020680673,
+        "Z": 2.099689
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.154922584Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 2,
+      "ImpactSpeed": 32.721474,
+      "WorldPos": {
+        "X": -154.8453,
+        "Y": 10.784038,
+        "Z": 437.71323
+      },
+      "RelPos": {
+        "X": -0.6782271,
+        "Y": 0.056191966,
+        "Z": 2.0357244
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.169529194Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 92.664604,
+      "WorldPos": {
+        "X": -158.38455,
+        "Y": 11.312611,
+        "Z": 434.4338
+      },
+      "RelPos": {
+        "X": 0.47544444,
+        "Y": 0.43887326,
+        "Z": -2.0617042
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.177888148Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 8,
+      "ImpactSpeed": 196.0419,
+      "WorldPos": {
+        "X": -137.17503,
+        "Y": 8.95841,
+        "Z": 433.2197
+      },
+      "RelPos": {
+        "X": -0.7918957,
+        "Y": -0.28072026,
+        "Z": -1.7505438
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.191592799Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 22.139364,
+      "WorldPos": {
+        "X": -140.57243,
+        "Y": 9.613563,
+        "Z": 438.40848
+      },
+      "RelPos": {
+        "X": 0.78596735,
+        "Y": 0.03938595,
+        "Z": 2.29819
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:48.29426582Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 7,
+      "ImpactSpeed": 23.275885,
+      "WorldPos": {
+        "X": -156.07387,
+        "Y": 11.1435795,
+        "Z": 437.5752
+      },
+      "RelPos": {
+        "X": 0.89219034,
+        "Y": -0.09828663,
+        "Z": -1.7184621
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:48.305346058Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 8,
+      "ImpactSpeed": 120.560486,
+      "WorldPos": {
+        "X": -154.25186,
+        "Y": 10.808504,
+        "Z": 437.4832
+      },
+      "RelPos": {
+        "X": 0.7558801,
+        "Y": 0.21606196,
+        "Z": -1.7522763
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:48.311324828Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 14.722476,
+      "WorldPos": {
+        "X": -154.972,
+        "Y": 10.327267,
+        "Z": 441.98355
+      },
+      "RelPos": {
+        "X": 5.066395e-7,
+        "Y": -0.26021084,
+        "Z": 2.635321
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:51.783451069Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 1,
+      "ImpactSpeed": 25.608603,
+      "WorldPos": {
+        "X": -146.17607,
+        "Y": 9.652548,
+        "Z": 433.87454
+      },
+      "RelPos": {
+        "X": 0.7500482,
+        "Y": -0.29149005,
+        "Z": 2.322259
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:51.88052647Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 8,
+      "ImpactSpeed": 9.089698,
+      "WorldPos": {
+        "X": -158.09119,
+        "Y": 11.318608,
+        "Z": 438.1805
+      },
+      "RelPos": {
+        "X": -0.37662733,
+        "Y": -0.26381376,
+        "Z": -1.243058
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:51.888313607Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 1.5732777,
+      "WorldPos": {
+        "X": -159.71603,
+        "Y": 10.633289,
+        "Z": 437.5311
+      },
+      "RelPos": {
+        "X": 0.96550643,
+        "Y": -0.26382113,
+        "Z": -1.2430785
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.112931089Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 7,
+      "ImpactSpeed": 2.0968513,
+      "WorldPos": {
+        "X": -157.75905,
+        "Y": 11.261579,
+        "Z": 437.76495
+      },
+      "RelPos": {
+        "X": 0.4891746,
+        "Y": 0.43232647,
+        "Z": -2.024809
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.120591818Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 3.4712164,
+      "WorldPos": {
+        "X": -144.16994,
+        "Y": 10.033469,
+        "Z": 439.29456
+      },
+      "RelPos": {
+        "X": -0.8929589,
+        "Y": 0.19192089,
+        "Z": 1.7670469
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.139506263Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 1,
+      "ImpactSpeed": 9.827558,
+      "WorldPos": {
+        "X": -144.2318,
+        "Y": 9.498784,
+        "Z": 437.49704
+      },
+      "RelPos": {
+        "X": 0.87976086,
+        "Y": -0.2966022,
+        "Z": 1.5720578
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.167020804Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 0,
+      "ImpactSpeed": 25.620605,
+      "WorldPos": {
+        "X": -145.73595,
+        "Y": 10.280885,
+        "Z": 434.49033
+      },
+      "RelPos": {
+        "X": -0.9303588,
+        "Y": 0.3876351,
+        "Z": -1.0479064
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.178323368Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 8,
+      "ImpactSpeed": 11.638,
+      "WorldPos": {
+        "X": -144.22736,
+        "Y": 9.488884,
+        "Z": 437.4958
+      },
+      "RelPos": {
+        "X": -0.7483559,
+        "Y": -0.33104643,
+        "Z": 2.3312452
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:55.229034507Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 61825,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 659795,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:55.853232714Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 67097,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 659795,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 660425,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.047530547Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 60591,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 659795,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 660425,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 16,
+          "LapTime": 661541,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.114959869Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 8.485209,
+      "WorldPos": {
+        "X": -140.0359,
+        "Y": 9.269851,
+        "Z": 438.2437
+      },
+      "RelPos": {
+        "X": -0.96426576,
+        "Y": -0.26377523,
+        "Z": -1.2430801
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.13331519Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 1,
+      "ImpactSpeed": 0.49061668,
+      "WorldPos": {
+        "X": -143.84271,
+        "Y": 9.422574,
+        "Z": 437.4544
+      },
+      "RelPos": {
+        "X": 0.8671616,
+        "Y": -0.26368892,
+        "Z": 1.4969919
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.164013996Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 8,
+      "ImpactSpeed": 0.2254504,
+      "WorldPos": {
+        "X": -144.09935,
+        "Y": 9.4405985,
+        "Z": 437.45807
+      },
+      "RelPos": {
+        "X": -0.6401783,
+        "Y": -0.33818176,
+        "Z": 2.3590064
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:04.608024521Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:10.23118229Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "1 more race"
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:17.651408203Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "niceone for waiting mate "
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:24.382836813Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 8,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:29.492673616Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "i drove worst evere blol"
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:29.930449375Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:32.039880526Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 15,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:35.81577258Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 0,
+      "Message": "yes"
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:44.811565046Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:46.862425475Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 7,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:57.100805796Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:03:05.264781186Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 16,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:03:13.336719501Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 19,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:03:13.354320226Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_22_3_RACE.json"
+  },
+  {
+    "Received": "2019-03-02T22:03:13.357803307Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": 1,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:03.488127912Z",
+    "EventType": 56,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T22:04:03.508500787Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 38,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:04.747857103Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 25,
+      "RoadTemp": 35,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:16.748916185Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 18,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:17.053159393Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:20.136255583Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:26.155157637Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:32.431648749Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 10,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:33.649983954Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:33.772023408Z",
+    "EventType": 58,
+    "Data": 18
+  },
+  {
+    "Received": "2019-03-02T22:04:41.321668359Z",
+    "EventType": 58,
+    "Data": 0
+  },
+  {
+    "Received": "2019-03-02T22:04:44.354267187Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T22:04:44.464251556Z",
+    "EventType": 58,
+    "Data": 10
+  },
+  {
+    "Received": "2019-03-02T22:04:45.49657591Z",
+    "EventType": 58,
+    "Data": 9
+  },
+  {
+    "Received": "2019-03-02T22:05:02.110305847Z",
+    "EventType": 58,
+    "Data": 5
+  },
+  {
+    "Received": "2019-03-02T22:06:05.57626289Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 81230,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:06.426895447Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 85146,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:10.121870891Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 85668,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:21.042946032Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 95577,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:41.471048637Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 99370,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:43.609792098Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 129830,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:07.320432731Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60893,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:10.483295297Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64906,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:12.182793575Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 62073,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:19.243552628Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58216,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:39.466227737Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 10.208012,
+      "WorldPos": {
+        "X": 880.6847,
+        "Y": -38.984524,
+        "Z": 548.5211
+      },
+      "RelPos": {
+        "X": 0.770637,
+        "Y": 0.03156123,
+        "Z": 2.1065946
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:47.04530853Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 63466,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:56.076898832Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 74620,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:59.369985824Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 42.370678,
+      "WorldPos": {
+        "X": 432.46927,
+        "Y": -17.26613,
+        "Z": 81.658394
+      },
+      "RelPos": {
+        "X": 1.0376282,
+        "Y": 0.25316912,
+        "Z": -1.0038949
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:04.37567441Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 2.3292015,
+      "WorldPos": {
+        "X": 431.48233,
+        "Y": -17.673098,
+        "Z": 85.09106
+      },
+      "RelPos": {
+        "X": 0.7518393,
+        "Y": -0.25798073,
+        "Z": 2.4633703
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.374642439Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 1.7273932,
+      "WorldPos": {
+        "X": 431.46,
+        "Y": -16.891727,
+        "Z": 85.17174
+      },
+      "RelPos": {
+        "X": 0.82837784,
+        "Y": -0.021093488,
+        "Z": 2.24126
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.391510025Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 30.361473,
+      "WorldPos": {
+        "X": 429.9293,
+        "Y": -17.499622,
+        "Z": 84.47097
+      },
+      "RelPos": {
+        "X": -0.6262179,
+        "Y": -0.3164721,
+        "Z": 1.241302
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.485865183Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 29.947628,
+      "WorldPos": {
+        "X": 430.91074,
+        "Y": -18.035736,
+        "Z": 87.15836
+      },
+      "RelPos": {
+        "X": -0.8619413,
+        "Y": -0.29390463,
+        "Z": 1.7960964
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.504841656Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 46.672718,
+      "WorldPos": {
+        "X": 430.31238,
+        "Y": -17.078253,
+        "Z": 85.66811
+      },
+      "RelPos": {
+        "X": -0.30221856,
+        "Y": 0.66334796,
+        "Z": 0.5874342
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.009471953Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 66684,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.373645175Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 13.129903,
+      "WorldPos": {
+        "X": 430.33582,
+        "Y": -17.117569,
+        "Z": 85.67888
+      },
+      "RelPos": {
+        "X": -0.3648863,
+        "Y": -0.25902927,
+        "Z": 2.553715
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.389020923Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 4.1745076,
+      "WorldPos": {
+        "X": 431.53217,
+        "Y": -17.21572,
+        "Z": 84.830414
+      },
+      "RelPos": {
+        "X": 0.93745446,
+        "Y": -0.29018098,
+        "Z": 1.8765396
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.473869733Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 18.47808,
+      "WorldPos": {
+        "X": 430.94147,
+        "Y": -17.263313,
+        "Z": 81.97111
+      },
+      "RelPos": {
+        "X": -0.8671918,
+        "Y": -0.29545838,
+        "Z": 1.7993759
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:18.456496624Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 59199,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:29.385402767Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 24.841875,
+      "WorldPos": {
+        "X": 329.60495,
+        "Y": -1.9889579,
+        "Z": -118.05477
+      },
+      "RelPos": {
+        "X": 0.40502715,
+        "Y": -0.26062295,
+        "Z": 2.5984235
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:42.136388459Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 89928,
+      "Cuts": 4,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:44.483920795Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 128.27638,
+      "WorldPos": {
+        "X": 528.2595,
+        "Y": -16.5767,
+        "Z": -76.93758
+      },
+      "RelPos": {
+        "X": -0.94752896,
+        "Y": -0.26441064,
+        "Z": -0.54707783
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:45.194695289Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 94695,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:49.452056349Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62385,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:16.353482476Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 62360,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:17.963796502Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 59498,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:26.705168275Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 90577,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:49.334321424Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64156,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:51.722561547Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62279,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:16.444920378Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60087,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:16.693263859Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58754,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:20.136683996Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 98023,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:34.891052426Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 68235,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:39.510311946Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 30.158163,
+      "WorldPos": {
+        "X": 1015.14514,
+        "Y": -40.457607,
+        "Z": 518.61237
+      },
+      "RelPos": {
+        "X": 0.5137355,
+        "Y": 0.039426297,
+        "Z": 2.2621727
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:50.530008487Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 61206,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:54.222258587Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62503,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:17.159805146Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 8.210459,
+      "WorldPos": {
+        "X": 454.6029,
+        "Y": -15.763637,
+        "Z": 240.63354
+      },
+      "RelPos": {
+        "X": -1.0029753,
+        "Y": 0.11470533,
+        "Z": -1.8480852
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:17.903422343Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 61451,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:21.027577895Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 64326,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:34.415723145Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 6.060513,
+      "WorldPos": {
+        "X": 402.2142,
+        "Y": -15.356009,
+        "Z": 171.58939
+      },
+      "RelPos": {
+        "X": 1.0323999,
+        "Y": 0.21087149,
+        "Z": -1.0133661
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:34.511612675Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 6.7570353,
+      "WorldPos": {
+        "X": 399.6484,
+        "Y": -15.566014,
+        "Z": 163.83081
+      },
+      "RelPos": {
+        "X": -0.9039753,
+        "Y": 0.18978673,
+        "Z": 1.5610628
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:39.417370453Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 19.327225,
+      "WorldPos": {
+        "X": 425.1303,
+        "Y": -15.261997,
+        "Z": 28.401909
+      },
+      "RelPos": {
+        "X": 0.9139701,
+        "Y": -0.26706657,
+        "Z": 1.9019012
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:39.512019482Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 13.065868,
+      "WorldPos": {
+        "X": 425.1153,
+        "Y": -15.232496,
+        "Z": 28.199049
+      },
+      "RelPos": {
+        "X": -0.9070022,
+        "Y": -0.17091325,
+        "Z": 1.1707482
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:51.345135386Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 9.316111,
+      "WorldPos": {
+        "X": 734.5443,
+        "Y": -27.534115,
+        "Z": 193.0971
+      },
+      "RelPos": {
+        "X": -0.7859765,
+        "Y": 0.039384842,
+        "Z": 2.2981675
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:52.817895262Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 77930,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:59.939894233Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 99802,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:01.990623633Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 71460,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:04.406080232Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 70196,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:20.07629095Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 59057,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:54.434053141Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 47.079132,
+      "WorldPos": {
+        "X": 439.4286,
+        "Y": -13.3221035,
+        "Z": 14.565399
+      },
+      "RelPos": {
+        "X": -0.782428,
+        "Y": 0.11593743,
+        "Z": 2.416308
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:59.094096121Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 66274,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:00.887301354Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60958,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:06.293604158Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 61864,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:20.353111541Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 78349,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:20.4238353Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 122542,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:23.851093026Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 18,
+      "ImpactSpeed": 35.786575,
+      "WorldPos": {
+        "X": 959.6878,
+        "Y": -42.73399,
+        "Z": 534.8381
+      },
+      "RelPos": {
+        "X": -0.8595867,
+        "Y": -0.23198149,
+        "Z": -0.441666
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:34.540791743Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 37.02332,
+      "WorldPos": {
+        "X": 851.09686,
+        "Y": -37.515785,
+        "Z": 514.4321
+      },
+      "RelPos": {
+        "X": 0.77143675,
+        "Y": 0.0312098,
+        "Z": 2.1078157
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:14:06.134220111Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 67033,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:14:27.199328138Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 31.278883,
+      "WorldPos": {
+        "X": 1013.32855,
+        "Y": -40.79059,
+        "Z": 527.4942
+      },
+      "RelPos": {
+        "X": -0.7531507,
+        "Y": -0.33792892,
+        "Z": 2.3337357
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:15:55.431607026Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_22_15_QUALIFY.json"
+  },
+  {
+    "Received": "2019-03-02T22:15:55.457241841Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 1,
+      "CurrentSessionIndex": 1,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Race",
+      "Type": 3,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 60000,
+      "AmbientTemp": 25,
+      "RoadTemp": 35,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": -59999,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:16:59.576936617Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 9,
+      "ImpactSpeed": 29.274994,
+      "WorldPos": {
+        "X": 731.3208,
+        "Y": -26.340197,
+        "Z": 141.48248
+      },
+      "RelPos": {
+        "X": -0.9493474,
+        "Y": -0.1772775,
+        "Z": -0.50101185
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:00.589067052Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 10,
+      "ImpactSpeed": 35.802395,
+      "WorldPos": {
+        "X": 731.3822,
+        "Y": -26.350153,
+        "Z": 141.50735
+      },
+      "RelPos": {
+        "X": 0.82416636,
+        "Y": -0.18334407,
+        "Z": -1.5189974
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:27.258576555Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 18,
+      "ImpactSpeed": 0.04724604,
+      "WorldPos": {
+        "X": 672.60394,
+        "Y": -32.71208,
+        "Z": 394.6068
+      },
+      "RelPos": {
+        "X": -0.09260625,
+        "Y": -0.22828183,
+        "Z": -1.9417348
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:28.905804508Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 18,
+      "OtherCarID": 5,
+      "ImpactSpeed": 0.9622092,
+      "WorldPos": {
+        "X": 673.09375,
+        "Y": -32.728104,
+        "Z": 394.9637
+      },
+      "RelPos": {
+        "X": -0.0000923574,
+        "Y": -0.07723366,
+        "Z": 2.4312825
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:55.602014036Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 5,
+      "ImpactSpeed": 5.1747684,
+      "WorldPos": {
+        "X": 318.17624,
+        "Y": -1.5074056,
+        "Z": -108.65015
+      },
+      "RelPos": {
+        "X": -0.9231553,
+        "Y": 0.18566407,
+        "Z": 1.1496537
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:56.44940531Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60998,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:57.241034347Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 9,
+      "ImpactSpeed": 4.0861115,
+      "WorldPos": {
+        "X": 318.17493,
+        "Y": -1.4920442,
+        "Z": -108.639046
+      },
+      "RelPos": {
+        "X": 1.010175,
+        "Y": 0.18538913,
+        "Z": -0.87796223
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:58.141494126Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 62696,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:01.082045314Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 65614,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:01.799592658Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 66348,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:02.514717389Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 67035,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:02.642686722Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 67164,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 67178,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:19.519447555Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 14.583844,
+      "WorldPos": {
+        "X": 959.93976,
+        "Y": -42.45596,
+        "Z": 534.0925
+      },
+      "RelPos": {
+        "X": -0.7780968,
+        "Y": 0.031857852,
+        "Z": 2.4402232
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:56.883296572Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60437,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 67178,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:02.474971216Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60682,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 67178,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:02.655285274Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 60029,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:04.729539889Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 63672,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:07.058267955Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 68907,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:08.775286933Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 66289,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:24.606761793Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 9,
+      "ImpactSpeed": 29.226295,
+      "WorldPos": {
+        "X": 874.05597,
+        "Y": -38.877777,
+        "Z": 571.55273
+      },
+      "RelPos": {
+        "X": 0.93989664,
+        "Y": 0.018473051,
+        "Z": -1.174458
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:25.61541752Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 10,
+      "ImpactSpeed": 31.032682,
+      "WorldPos": {
+        "X": 874.09625,
+        "Y": -38.89613,
+        "Z": 571.54816
+      },
+      "RelPos": {
+        "X": -0.7586524,
+        "Y": 0.017954648,
+        "Z": 2.0891225
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:29.609639762Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 18.212961,
+      "WorldPos": {
+        "X": 819.7805,
+        "Y": -37.148586,
+        "Z": 561.0042
+      },
+      "RelPos": {
+        "X": -0.7714222,
+        "Y": 0.031207677,
+        "Z": 2.1077607
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:56.6830956Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59798,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:03.708788297Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 60986,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:06.434502749Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 61703,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:11.732091608Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 62970,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:14.725736981Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 72262,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:18.451431028Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 71410,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:56.470308278Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59789,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:02.122097759Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58462,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:08.640771584Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62202,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:15.422556126Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 63688,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:15.661170491Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60931,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:21.080650048Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 62627,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:56.176570475Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59708,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:00.218967316Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58127,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:10.74916945Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62095,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:16.263176936Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60594,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:19.166035755Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 63726,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:25.136210669Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64051,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:47.857006695Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarMode": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:56.923902026Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60757,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:58.493854929Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58237,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:12.62026879Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 61885,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:18.332244305Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 62073,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:36.187508311Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 77044,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:52.308316433Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 29.461843,
+      "WorldPos": {
+        "X": 972.1922,
+        "Y": -41.874866,
+        "Z": 483.02713
+      },
+      "RelPos": {
+        "X": -0.7531311,
+        "Y": -0.3379306,
+        "Z": 2.3337069
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:56.521575709Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59608,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:56.83746289Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58375,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:19.826861955Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 61497,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:26.128980689Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 73500,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:48.233469058Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 72023,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:58.000113936Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 61161,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:58.305760797Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 61777,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:15.686784972Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 0,
+      "ImpactSpeed": 15.259357,
+      "WorldPos": {
+        "X": 963.2201,
+        "Y": -41.728924,
+        "Z": 562.36316
+      },
+      "RelPos": {
+        "X": -0.96013355,
+        "Y": 0.11289532,
+        "Z": -0.6887216
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:16.509186943Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 9,
+      "ImpactSpeed": 10.878339,
+      "WorldPos": {
+        "X": 963.06335,
+        "Y": -41.66753,
+        "Z": 562.5592
+      },
+      "RelPos": {
+        "X": 0.9960668,
+        "Y": 0.25453144,
+        "Z": 1.3268081
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:21.274078643Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 61452,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:28.302803301Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62181,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:54.817024017Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 66594,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:00.851566174Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 62851,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:01.638571645Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63338,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:22.901867163Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 61627,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:38.945184846Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 70640,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:00.513296546Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 65704,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:01.666366355Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60005,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:10.349987713Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 69485,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:25.708871079Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 9,
+      "ImpactSpeed": 90.43727,
+      "WorldPos": {
+        "X": 1015.6104,
+        "Y": -40.448257,
+        "Z": 516.2672
+      },
+      "RelPos": {
+        "X": 0.7714079,
+        "Y": 0.031207928,
+        "Z": 2.1077886
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:29.569359312Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 66664,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 634118,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:30.702371409Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 9,
+      "ImpactSpeed": 6.7225127,
+      "WorldPos": {
+        "X": 1011.8523,
+        "Y": -40.470596,
+        "Z": 534.69403
+      },
+      "RelPos": {
+        "X": 0.7714232,
+        "Y": 0.03120906,
+        "Z": 2.1077783
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:41.403189367Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62440,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 634118,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 18,
+          "LapTime": 645925,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:44.721340534Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 129.45352,
+      "WorldPos": {
+        "X": 1022.6137,
+        "Y": -40.4104,
+        "Z": 485.11365
+      },
+      "RelPos": {
+        "X": -0.6565897,
+        "Y": -0.23697315,
+        "Z": 2.0269265
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:09.400933569Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 68901,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 634118,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 18,
+          "LapTime": 645925,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 673959,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:09.702349046Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 57.04306,
+      "WorldPos": {
+        "X": 850.11346,
+        "Y": -37.75909,
+        "Z": 512.9045
+      },
+      "RelPos": {
+        "X": 0.96553004,
+        "Y": -0.26382154,
+        "Z": -1.2430332
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:16.025631943Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 18,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarMode": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:17.071204427Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 10,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:20.412880097Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:36.518062594Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarMode": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:56.403955889Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarMode": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:56.427468605Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_22_28_RACE.json"
+  },
+  {
+    "Received": "2019-03-02T22:28:56.428255604Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 25,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": 1,
+      "EventType": 50
+    }
+  }
+]

--- a/fixtures/open-championship/championship-setup.json
+++ b/fixtures/open-championship/championship-setup.json
@@ -1,0 +1,4072 @@
+{
+  "ID": "b412c28d-b0d5-41e8-b551-7704e11fe35a",
+  "Name": "Open championship test",
+  "Created": "2019-03-02T12:55:42.831095556Z",
+  "Updated": "2019-03-02T22:28:56.419922652Z",
+  "Deleted": "0001-01-01T00:00:00Z",
+  "OpenEntrants": true,
+  "Classes": [
+    {
+      "Name": "NFS",
+      "Entrants": {
+        "CAR_0": {
+          "Name": "Seb",
+          "Team": "",
+          "GUID": "76561198074322763",
+          "Model": "a3dr_lambo_diablo_vt",
+          "Skin": "Viola_Ophelia",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_1": {
+          "Name": "namelesssboy",
+          "Team": "",
+          "GUID": "76561198022717360",
+          "Model": "a3dr_lambo_diablo_vt",
+          "Skin": "Silver",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_2": {
+          "Name": "Danny Wilson",
+          "Team": "",
+          "GUID": "76561198023931313",
+          "Model": "a3dr_ferrari_512tr",
+          "Skin": "Rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_3": {
+          "Name": "Spaceman9795",
+          "Team": "",
+          "GUID": "76561198045844392",
+          "Model": "a3dr_lambo_diablo_vt",
+          "Skin": "Blu_Oscuro",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_4": {
+          "Name": "rich p",
+          "Team": "",
+          "GUID": "76561198437072463",
+          "Model": "a3dr_lambo_diablo_vt",
+          "Skin": "Blu_Oscuro",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_5": {
+          "Name": "Cheezypoof",
+          "Team": "",
+          "GUID": "76561198365646634",
+          "Model": "a3dr_ferrari_512tr",
+          "Skin": "Giallo_Modena",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        }
+      },
+      "Points": {
+        "Places": [
+          25,
+          18,
+          15,
+          12,
+          10,
+          8
+        ],
+        "BestLap": 0,
+        "PolePosition": 0
+      }
+    },
+    {
+      "Name": "Porsche",
+      "Entrants": {
+        "CAR_0": {
+          "Name": "L33 CR055L3Y",
+          "Team": "",
+          "GUID": "76561198055388877",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "10_carrera_grey",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_1": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "01_racing_red",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_2": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "10_carrera_grey",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_3": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "11_carrera_lime",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_4": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "10_carrera_grey",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_5": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "21_kunosracing_75",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_6": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "03_kunosracing_17",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_7": {
+          "Name": "Joseph Elton",
+          "Team": "",
+          "GUID": "76561198029578060",
+          "Model": "ks_porsche_911_carrera_rsr",
+          "Skin": "03_kunosracing_17",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        }
+      },
+      "Points": {
+        "Places": [
+          25,
+          18,
+          15,
+          12,
+          10,
+          8,
+          6,
+          4
+        ],
+        "BestLap": 0,
+        "PolePosition": 0
+      }
+    },
+    {
+      "Name": "Alfa",
+      "Entrants": {
+        "CAR_0": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_1": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_2": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_3": {
+          "Name": "Callum Jones",
+          "Team": "",
+          "GUID": "76561198020046073",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_4": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_5": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_6": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        },
+        "CAR_7": {
+          "Name": "",
+          "Team": "",
+          "GUID": "",
+          "Model": "ks_alfa_33_stradale",
+          "Skin": "00_rosso",
+          "Ballast": 0,
+          "SpectatorMode": 0,
+          "Restrictor": 0
+        }
+      },
+      "Points": {
+        "Places": [
+          25,
+          18,
+          15,
+          12,
+          10,
+          8,
+          6,
+          4
+        ],
+        "BestLap": 0,
+        "PolePosition": 0
+      }
+    }
+  ],
+  "Events": [
+    {
+      "ID": "afc53e20-36f4-4a4c-b4dc-2c75d3da437e",
+      "RaceSetup": {
+        "Cars": "ks_ferrari_fxx_k;ks_lamborghini_huracan_st;ks_porsche_911_gt3_cup_2017",
+        "Track": "road_atlanta2018",
+        "TrackLayout": "shortcourse",
+        "SunAngle": 0,
+        "LegalTyres": "H;M;S",
+        "FuelRate": 100,
+        "DamageMultiplier": 0,
+        "TyreWearRate": 100,
+        "AllowedTyresOut": 3,
+        "ABSAllowed": 1,
+        "TractionControlAllowed": 1,
+        "StabilityControlAllowed": 0,
+        "AutoClutchAllowed": 0,
+        "TyreBlanketsAllowed": 1,
+        "ForceVirtualMirror": 0,
+        "LockedEntryList": 0,
+        "RacePitWindowStart": 0,
+        "RacePitWindowEnd": 0,
+        "ReversedGridRacePositions": 0,
+        "TimeOfDayMultiplier": 0,
+        "QualifyMaxWaitPercentage": 200,
+        "RaceGasPenaltyDisabled": 1,
+        "MaxBallastKilograms": 50,
+        "RaceExtraLap": 0,
+        "PickupModeEnabled": 1,
+        "LoopMode": 1,
+        "MaxClients": 0,
+        "SleepTime": 0,
+        "RaceOverTime": 180,
+        "StartRule": 2,
+        "IsSol": 1,
+        "WindBaseSpeedMin": 3,
+        "WindBaseSpeedMax": 15,
+        "WindBaseDirection": 30,
+        "WindVariationDirection": 15,
+        "DynamicTrack": {
+          "SessionStart": 100,
+          "Randomness": 0,
+          "SessionTransfer": 100,
+          "LapGain": 1
+        },
+        "Sessions": {
+          "QUALIFY": {
+            "Name": "Qualify",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 0
+          },
+          "RACE": {
+            "Name": "Race",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 60
+          }
+        },
+        "Weather": {
+          "WEATHER_0": {
+            "Graphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530198000",
+            "BaseTemperatureAmbient": 26,
+            "BaseTemperatureRoad": 11,
+            "VariationAmbient": 1,
+            "VariationRoad": 1,
+            "CMGraphics": "sol_01_CLear",
+            "CMWFXType": 15,
+            "CMWFXUseCustomTime": 1,
+            "CMWFXTime": 0,
+            "CMWFXTimeMulti": 15,
+            "CMWFXUseCustomDate": 1,
+            "CMWFXDate": 1530198000,
+            "CMWFXDateUnModified": 1530468000
+          }
+        }
+      },
+      "Sessions": {
+        "QUALIFY": {
+          "StartedTime": "2019-03-02T20:35:23.044321908Z",
+          "CompletedTime": "2019-03-02T20:48:12.604730869Z",
+          "Results": {
+            "Cars": [
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "Driver": {
+                  "Guid": "76561198074322763",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Seb",
+                  "Nation": "ITA",
+                  "Team": ""
+                },
+                "Model": "a3dr_lambo_diablo_vt",
+                "Restrictor": 0,
+                "Skin": "Viola_Ophelia"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "Model": "a3dr_ferrari_512tr",
+                "Restrictor": 0,
+                "Skin": "Rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 2,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "a3dr_ferrari_512tr",
+                "Restrictor": 0,
+                "Skin": "Giallo_Modena"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 3,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "a3dr_ferrari_512tr",
+                "Restrictor": 0,
+                "Skin": "Argento_Nurburgring"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "Model": "a3dr_lambo_diablo_vt",
+                "Restrictor": 0,
+                "Skin": "Silver"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 5,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "a3dr_lambo_diablo_vt",
+                "Restrictor": 0,
+                "Skin": "Blu_Oscuro"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "Driver": {
+                  "Guid": "76561198029578060",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Joseph Elton",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "03_kunosracing_17"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "10_carrera_grey"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 8,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "12_carrera_red"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 9,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "01_racing_red"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 10,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "10_carrera_grey"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 11,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "11_carrera_lime"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 12,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "10_carrera_grey"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 13,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "21_kunosracing_75"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "Driver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 15,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 16,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 17,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 18,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 19,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 20,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 21,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              }
+            ],
+            "Events": [
+              {
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "ImpactSpeed": 3.4481761,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.8726334,
+                  "Y": 0.009840868,
+                  "Z": -1.845053
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 99.4912,
+                  "Y": -0.68025404,
+                  "Z": 707.87445
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 41.323658,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.7582626,
+                  "Y": 0.06732882,
+                  "Z": 2.0806212
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 341.26077,
+                  "Y": -10.3295145,
+                  "Z": 321.75922
+                }
+              },
+              {
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "ImpactSpeed": 9.23848,
+                "OtherCarId": 7,
+                "OtherDriver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.07931602,
+                  "Y": -0.055294245,
+                  "Z": 2.5751386
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": 343.1826,
+                  "Y": -7.748003,
+                  "Z": 355.5595
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 9.523971,
+                "OtherCarId": 1,
+                "OtherDriver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.59326816,
+                  "Y": -0.09772314,
+                  "Z": -1.8515455
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": 343.10892,
+                  "Y": -7.7217207,
+                  "Z": 355.58014
+                }
+              },
+              {
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "ImpactSpeed": 24.010284,
+                "OtherCarId": 7,
+                "OtherDriver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.9369556,
+                  "Y": -0.07468344,
+                  "Z": 0.9083626
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": 164.11401,
+                  "Y": 5.312757,
+                  "Z": 609.72156
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 21.739614,
+                "OtherCarId": 1,
+                "OtherDriver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.3763247,
+                  "Y": -0.030625097,
+                  "Z": 2.2685776
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": 194.22424,
+                  "Y": 6.9305124,
+                  "Z": 579.99774
+                }
+              },
+              {
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "ImpactSpeed": 40.02642,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.7846885,
+                  "Y": 0.11835694,
+                  "Z": 2.4270966
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 208.16618,
+                  "Y": 7.1062746,
+                  "Z": 596.93567
+                }
+              },
+              {
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 27.531704,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 1.052376,
+                  "Y": 0.3593424,
+                  "Z": 0.99950933
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 349.54358,
+                  "Y": -10.715356,
+                  "Z": 305.65845
+                }
+              },
+              {
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "ImpactSpeed": 94.74097,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.782713,
+                  "Y": 0.116233096,
+                  "Z": 2.4177246
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -370.9807,
+                  "Y": 16.781279,
+                  "Z": 840.7675
+                }
+              },
+              {
+                "CarId": 14,
+                "Driver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "ImpactSpeed": 7.680085,
+                "OtherCarId": 0,
+                "OtherDriver": {
+                  "Guid": "76561198074322763",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Seb",
+                  "Nation": "ITA",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.76427066,
+                  "Y": 0.27832294,
+                  "Z": 1.8490028
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": -363.5298,
+                  "Y": 12.709884,
+                  "Z": 191.78935
+                }
+              },
+              {
+                "CarId": 0,
+                "Driver": {
+                  "Guid": "76561198074322763",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Seb",
+                  "Nation": "ITA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 10.999591,
+                "OtherCarId": 14,
+                "OtherDriver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.96988446,
+                  "Y": 0.15765344,
+                  "Z": -0.22623976
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": -363.4594,
+                  "Y": 12.719616,
+                  "Z": 191.93095
+                }
+              },
+              {
+                "CarId": 14,
+                "Driver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "ImpactSpeed": 59.23574,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.5419191,
+                  "Y": -0.21236464,
+                  "Z": 2.2094166
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 103.05621,
+                  "Y": -3.3374496,
+                  "Z": 78.1993
+                }
+              },
+              {
+                "CarId": 14,
+                "Driver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "ImpactSpeed": 9.414676,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.8957843,
+                  "Y": 0.24130149,
+                  "Z": -0.7263129
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 206.03058,
+                  "Y": -5.4474707,
+                  "Z": 143.57832
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 25.261316,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.89031905,
+                  "Y": 0.1535878,
+                  "Z": 1.7694017
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 348.63605,
+                  "Y": -10.713557,
+                  "Z": 314.12927
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 106.91365,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.45802307,
+                  "Y": 0.38255495,
+                  "Z": -2.0296555
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -78.33531,
+                  "Y": -16.3712,
+                  "Z": 876.70087
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 42.98267,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.4754539,
+                  "Y": 0.43887502,
+                  "Z": -2.0616727
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -63.352352,
+                  "Y": -16.49251,
+                  "Z": 854.4915
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 39.754715,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.79672116,
+                  "Y": -0.05505785,
+                  "Z": 2.0263412
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -66.21568,
+                  "Y": -17.24809,
+                  "Z": 858.076
+                }
+              }
+            ],
+            "Laps": [
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 113023,
+                "Restrictor": 0,
+                "Sectors": [
+                  87890,
+                  25133
+                ],
+                "Timestamp": 149122,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 1,
+                "CarModel": "a3dr_ferrari_512tr",
+                "Cuts": 2,
+                "DriverGuid": "76561198023931313",
+                "DriverName": "Danny Wilson",
+                "LapTime": 125704,
+                "Restrictor": 0,
+                "Sectors": [
+                  96481,
+                  29223
+                ],
+                "Timestamp": 210297,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 1,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 87540,
+                "Restrictor": 0,
+                "Sectors": [
+                  62839,
+                  24701
+                ],
+                "Timestamp": 236663,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 1,
+                "CarModel": "a3dr_ferrari_512tr",
+                "Cuts": 2,
+                "DriverGuid": "76561198023931313",
+                "DriverName": "Danny Wilson",
+                "LapTime": 98344,
+                "Restrictor": 0,
+                "Sectors": [
+                  68307,
+                  30037
+                ],
+                "Timestamp": 308641,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 85945,
+                "Restrictor": 0,
+                "Sectors": [
+                  60952,
+                  24993
+                ],
+                "Timestamp": 322606,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 1,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 109059,
+                "Restrictor": 0,
+                "Sectors": [
+                  80250,
+                  28809
+                ],
+                "Timestamp": 380744,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 1,
+                "CarModel": "a3dr_ferrari_512tr",
+                "Cuts": 1,
+                "DriverGuid": "76561198023931313",
+                "DriverName": "Danny Wilson",
+                "LapTime": 83647,
+                "Restrictor": 0,
+                "Sectors": [
+                  58555,
+                  25092
+                ],
+                "Timestamp": 392288,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 72969,
+                "Restrictor": 0,
+                "Sectors": [
+                  48722,
+                  24247
+                ],
+                "Timestamp": 395576,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 383117,
+                "Restrictor": 0,
+                "Sectors": [
+                  359960,
+                  23157
+                ],
+                "Timestamp": 431000,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 2,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 82448,
+                "Restrictor": 0,
+                "Sectors": [
+                  54711,
+                  27737
+                ],
+                "Timestamp": 463193,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 1,
+                "CarModel": "a3dr_ferrari_512tr",
+                "Cuts": 0,
+                "DriverGuid": "76561198023931313",
+                "DriverName": "Danny Wilson",
+                "LapTime": 71681,
+                "Restrictor": 0,
+                "Sectors": [
+                  46783,
+                  24898
+                ],
+                "Timestamp": 463967,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 73786,
+                "Restrictor": 0,
+                "Sectors": [
+                  49239,
+                  24547
+                ],
+                "Timestamp": 469361,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 68204,
+                "Restrictor": 0,
+                "Sectors": [
+                  45529,
+                  22675
+                ],
+                "Timestamp": 498970,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 2,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 75966,
+                "Restrictor": 0,
+                "Sectors": [
+                  48435,
+                  27531
+                ],
+                "Timestamp": 545328,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 2,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 82658,
+                "Restrictor": 0,
+                "Sectors": [
+                  56005,
+                  26653
+                ],
+                "Timestamp": 545847,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 1,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 66746,
+                "Restrictor": 0,
+                "Sectors": [
+                  44337,
+                  22409
+                ],
+                "Timestamp": 565714,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 1,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 99825,
+                "Restrictor": 0,
+                "Sectors": [
+                  75444,
+                  24381
+                ],
+                "Timestamp": 571851,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 77348,
+                "Restrictor": 0,
+                "Sectors": [
+                  51213,
+                  26135
+                ],
+                "Timestamp": 623194,
+                "Tyre": "SM"
+              }
+            ],
+            "Result": [
+              {
+                "BallastKG": 0,
+                "BestLap": 68204,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "Restrictor": 0,
+                "TotalTime": 497689,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 71681,
+                "CarId": 1,
+                "CarModel": "a3dr_ferrari_512tr",
+                "DriverGuid": "76561198023931313",
+                "DriverName": "Danny Wilson",
+                "Restrictor": 0,
+                "TotalTime": 462694,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 72969,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "Restrictor": 0,
+                "TotalTime": 468086,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 77348,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "Restrictor": 0,
+                "TotalTime": 621919,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 2,
+                "CarModel": "a3dr_ferrari_512tr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 5,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 8,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 9,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 10,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 3,
+                "CarModel": "a3dr_ferrari_512tr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 12,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 13,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 11,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 15,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 16,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 17,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 18,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 19,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 20,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 21,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              }
+            ],
+            "TrackConfig": "shortcourse",
+            "TrackName": "road_atlanta2018",
+            "Type": "QUALIFY",
+            "Date": "2019-03-02T20:48:00Z",
+            "SessionFile": "2019_3_2_20_48_QUALIFY",
+            "ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+          }
+        },
+        "RACE": {
+          "StartedTime": "2019-03-02T20:48:12.60869595Z",
+          "CompletedTime": "2019-03-02T21:04:10.635944651Z",
+          "Results": {
+            "Cars": [
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "Driver": {
+                  "Guid": "76561198074322763",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Seb",
+                  "Nation": "ITA",
+                  "Team": ""
+                },
+                "Model": "a3dr_lambo_diablo_vt",
+                "Restrictor": 0,
+                "Skin": "Viola_Ophelia"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 1,
+                "Driver": {
+                  "Guid": "76561198023931313",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Danny Wilson",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "Model": "a3dr_ferrari_512tr",
+                "Restrictor": 0,
+                "Skin": "Rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 2,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "a3dr_ferrari_512tr",
+                "Restrictor": 0,
+                "Skin": "Giallo_Modena"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 3,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "a3dr_ferrari_512tr",
+                "Restrictor": 0,
+                "Skin": "Argento_Nurburgring"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "Model": "a3dr_lambo_diablo_vt",
+                "Restrictor": 0,
+                "Skin": "Silver"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 5,
+                "Driver": {
+                  "Guid": "76561198045844392",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Spaceman9795",
+                  "Nation": "USA",
+                  "Team": ""
+                },
+                "Model": "a3dr_lambo_diablo_vt",
+                "Restrictor": 0,
+                "Skin": "Blu_Oscuro"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "Driver": {
+                  "Guid": "76561198029578060",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Joseph Elton",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "03_kunosracing_17"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "10_carrera_grey"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 8,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "12_carrera_red"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 9,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "01_racing_red"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 10,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "10_carrera_grey"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 11,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "11_carrera_lime"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 12,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "10_carrera_grey"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 13,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_porsche_911_carrera_rsr",
+                "Restrictor": 0,
+                "Skin": "21_kunosracing_75"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "Driver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 15,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 16,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 17,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 18,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 19,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 20,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 21,
+                "Driver": {
+                  "Guid": "",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "Model": "ks_alfa_33_stradale",
+                "Restrictor": 0,
+                "Skin": "00_rosso"
+              }
+            ],
+            "Events": [
+              {
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 24.245506,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.78595805,
+                  "Y": 0.039386205,
+                  "Z": 2.2981842
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 337.47366,
+                  "Y": -9.342905,
+                  "Z": 334.0582
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 23.33455,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.46135074,
+                  "Y": 0.037888948,
+                  "Z": 2.2632244
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 119.48544,
+                  "Y": 3.602386,
+                  "Z": 608.40356
+                }
+              },
+              {
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 93.99738,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.7796812,
+                  "Y": 0.03254054,
+                  "Z": 2.2683103
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -372.3561,
+                  "Y": 16.759512,
+                  "Z": 839.4282
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 11.575833,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.000009434298,
+                  "Y": 0.02099806,
+                  "Z": 2.3114219
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -205.51936,
+                  "Y": -4.0964437,
+                  "Z": 956.89215
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 58.248055,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.9078875,
+                  "Y": 0.14932533,
+                  "Z": -0.5796213
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 392.36182,
+                  "Y": -11.456185,
+                  "Z": 294.39423
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 61.18317,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.82921624,
+                  "Y": 0.31166998,
+                  "Z": -0.5896139
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 51.47633,
+                  "Y": -1.3451948,
+                  "Z": 45.277203
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 11.944935,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.47545153,
+                  "Y": 0.43887287,
+                  "Z": -2.0617037
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 99.42345,
+                  "Y": -2.4284506,
+                  "Z": 75.82876
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 26.496397,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.754289,
+                  "Y": -0.053788655,
+                  "Z": 2.0941443
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 147.19011,
+                  "Y": -4.492675,
+                  "Z": 106.252945
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 25.00765,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.7250676,
+                  "Y": -0.08441716,
+                  "Z": 2.074926
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -84.23594,
+                  "Y": -16.541346,
+                  "Z": 884.10474
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 4.132443,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.6663108,
+                  "Y": -0.09347161,
+                  "Z": -1.8271179
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -88.331245,
+                  "Y": -16.191883,
+                  "Z": 889.03125
+                }
+              },
+              {
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 44.95503,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.748965,
+                  "Y": 0.027728407,
+                  "Z": 2.2681112
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 351.3514,
+                  "Y": -11.066508,
+                  "Z": 310.14713
+                }
+              },
+              {
+                "CarId": 14,
+                "Driver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "ImpactSpeed": 8.127973,
+                "OtherCarId": 6,
+                "OtherDriver": {
+                  "Guid": "76561198029578060",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Joseph Elton",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.5227216,
+                  "Y": -0.010529488,
+                  "Z": 2.2386231
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": -336.22775,
+                  "Y": 8.570851,
+                  "Z": 291.50876
+                }
+              },
+              {
+                "CarId": 6,
+                "Driver": {
+                  "Guid": "76561198029578060",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Joseph Elton",
+                  "Nation": "GBR",
+                  "Team": ""
+                },
+                "ImpactSpeed": 9.576664,
+                "OtherCarId": 14,
+                "OtherDriver": {
+                  "Guid": "76561198020046073",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Callum Jones",
+                  "Nation": "ABW",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.6575319,
+                  "Y": -0.26483682,
+                  "Z": -0.4538347
+                },
+                "Type": "COLLISION_WITH_CAR",
+                "WorldPosition": {
+                  "X": -336.53696,
+                  "Y": 8.513263,
+                  "Z": 293.70697
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 45.0264,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.94368994,
+                  "Y": 0.15626273,
+                  "Z": -1.2444124
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": -63.108425,
+                  "Y": 3.557945,
+                  "Z": -54.179726
+                }
+              },
+              {
+                "CarId": 0,
+                "Driver": {
+                  "Guid": "76561198074322763",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "Seb",
+                  "Nation": "ITA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 52.866833,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.7793544,
+                  "Y": 0.03210375,
+                  "Z": 2.2664547
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 353.3642,
+                  "Y": -11.434663,
+                  "Z": 300.88672
+                }
+              },
+              {
+                "CarId": 4,
+                "Driver": {
+                  "Guid": "76561198022717360",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "namelesssboy",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 45.857872,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": -0.4035101,
+                  "Y": -0.34405965,
+                  "Z": 2.4484196
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 354.35977,
+                  "Y": -12.172672,
+                  "Z": 281.01334
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 10.350677,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.7714395,
+                  "Y": 0.031208891,
+                  "Z": 2.1077933
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 27.258234,
+                  "Y": -0.1833095,
+                  "Z": -1.9857945
+                }
+              },
+              {
+                "CarId": 7,
+                "Driver": {
+                  "Guid": "76561198055388877",
+                  "GuidsList": [
+                    ""
+                  ],
+                  "Name": "L33 CR055L3Y",
+                  "Nation": "PLA",
+                  "Team": ""
+                },
+                "ImpactSpeed": 12.220794,
+                "OtherCarId": -1,
+                "OtherDriver": {
+                  "Guid": "",
+                  "GuidsList": null,
+                  "Name": "",
+                  "Nation": "",
+                  "Team": ""
+                },
+                "RelPosition": {
+                  "X": 0.72866845,
+                  "Y": -0.034977205,
+                  "Z": -1.6889089
+                },
+                "Type": "COLLISION_WITH_ENV",
+                "WorldPosition": {
+                  "X": 59.541283,
+                  "Y": -1.5393885,
+                  "Z": 18.720987
+                }
+              }
+            ],
+            "Laps": [
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 74161,
+                "Restrictor": 0,
+                "Sectors": [
+                  51314,
+                  22847
+                ],
+                "Timestamp": 903740,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 82432,
+                "Restrictor": 0,
+                "Sectors": [
+                  56678,
+                  25754
+                ],
+                "Timestamp": 912003,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 85200,
+                "Restrictor": 0,
+                "Sectors": [
+                  57416,
+                  27784
+                ],
+                "Timestamp": 914770,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 111341,
+                "Restrictor": 0,
+                "Sectors": [
+                  85111,
+                  26230
+                ],
+                "Timestamp": 940916,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 130310,
+                "Restrictor": 0,
+                "Sectors": [
+                  94846,
+                  35464
+                ],
+                "Timestamp": 959877,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 71326,
+                "Restrictor": 0,
+                "Sectors": [
+                  44159,
+                  27167
+                ],
+                "Timestamp": 975065,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 75304,
+                "Restrictor": 0,
+                "Sectors": [
+                  49802,
+                  25502
+                ],
+                "Timestamp": 987306,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 88857,
+                "Restrictor": 0,
+                "Sectors": [
+                  48221,
+                  40636
+                ],
+                "Timestamp": 1003628,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 69869,
+                "Restrictor": 0,
+                "Sectors": [
+                  46253,
+                  23616
+                ],
+                "Timestamp": 1010782,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 67064,
+                "Restrictor": 0,
+                "Sectors": [
+                  44614,
+                  22450
+                ],
+                "Timestamp": 1042126,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 100946,
+                "Restrictor": 0,
+                "Sectors": [
+                  70823,
+                  30123
+                ],
+                "Timestamp": 1060819,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 75862,
+                "Restrictor": 0,
+                "Sectors": [
+                  50626,
+                  25236
+                ],
+                "Timestamp": 1063164,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 75626,
+                "Restrictor": 0,
+                "Sectors": [
+                  50444,
+                  25182
+                ],
+                "Timestamp": 1079252,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 74536,
+                "Restrictor": 0,
+                "Sectors": [
+                  50241,
+                  24295
+                ],
+                "Timestamp": 1085316,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 66890,
+                "Restrictor": 0,
+                "Sectors": [
+                  44584,
+                  22306
+                ],
+                "Timestamp": 1109111,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 79571,
+                "Restrictor": 0,
+                "Sectors": [
+                  54349,
+                  25222
+                ],
+                "Timestamp": 1140387,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 85559,
+                "Restrictor": 0,
+                "Sectors": [
+                  51958,
+                  33601
+                ],
+                "Timestamp": 1148722,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 74550,
+                "Restrictor": 0,
+                "Sectors": [
+                  49359,
+                  25191
+                ],
+                "Timestamp": 1153802,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 76766,
+                "Restrictor": 0,
+                "Sectors": [
+                  52817,
+                  23949
+                ],
+                "Timestamp": 1162079,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 66769,
+                "Restrictor": 0,
+                "Sectors": [
+                  44130,
+                  22639
+                ],
+                "Timestamp": 1175781,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 75328,
+                "Restrictor": 0,
+                "Sectors": [
+                  50614,
+                  24714
+                ],
+                "Timestamp": 1224047,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 73930,
+                "Restrictor": 0,
+                "Sectors": [
+                  49347,
+                  24583
+                ],
+                "Timestamp": 1227734,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 74369,
+                "Restrictor": 0,
+                "Sectors": [
+                  50983,
+                  23386
+                ],
+                "Timestamp": 1236445,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 66930,
+                "Restrictor": 0,
+                "Sectors": [
+                  44043,
+                  22887
+                ],
+                "Timestamp": 1242711,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 112386,
+                "Restrictor": 0,
+                "Sectors": [
+                  87145,
+                  25241
+                ],
+                "Timestamp": 1252772,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 73599,
+                "Restrictor": 0,
+                "Sectors": [
+                  48120,
+                  25479
+                ],
+                "Timestamp": 1297646,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 72145,
+                "Restrictor": 0,
+                "Sectors": [
+                  47773,
+                  24372
+                ],
+                "Timestamp": 1299878,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 67266,
+                "Restrictor": 0,
+                "Sectors": [
+                  44649,
+                  22617
+                ],
+                "Timestamp": 1309975,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 78410,
+                "Restrictor": 0,
+                "Sectors": [
+                  54673,
+                  23737
+                ],
+                "Timestamp": 1314853,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 95094,
+                "Restrictor": 0,
+                "Sectors": [
+                  69961,
+                  25133
+                ],
+                "Timestamp": 1347865,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 81946,
+                "Restrictor": 0,
+                "Sectors": [
+                  55360,
+                  26586
+                ],
+                "Timestamp": 1381821,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 86710,
+                "Restrictor": 0,
+                "Sectors": [
+                  57946,
+                  28764
+                ],
+                "Timestamp": 1384353,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 73794,
+                "Restrictor": 0,
+                "Sectors": [
+                  50376,
+                  23418
+                ],
+                "Timestamp": 1388646,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 80239,
+                "Restrictor": 0,
+                "Sectors": [
+                  45225,
+                  35014
+                ],
+                "Timestamp": 1390213,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 73256,
+                "Restrictor": 0,
+                "Sectors": [
+                  48785,
+                  24471
+                ],
+                "Timestamp": 1455075,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 109007,
+                "Restrictor": 0,
+                "Sectors": [
+                  56848,
+                  52159
+                ],
+                "Timestamp": 1456884,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 68822,
+                "Restrictor": 0,
+                "Sectors": [
+                  45567,
+                  23255
+                ],
+                "Timestamp": 1457465,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "LapTime": 67384,
+                "Restrictor": 0,
+                "Sectors": [
+                  44380,
+                  23004
+                ],
+                "Timestamp": 1457594,
+                "Tyre": "V70"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "LapTime": 73500,
+                "Restrictor": 0,
+                "Sectors": [
+                  48264,
+                  25236
+                ],
+                "Timestamp": 1457852,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "Cuts": 0,
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "LapTime": 72858,
+                "Restrictor": 0,
+                "Sectors": [
+                  47311,
+                  25547
+                ],
+                "Timestamp": 1527934,
+                "Tyre": "V"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "Cuts": 0,
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "LapTime": 77718,
+                "Restrictor": 0,
+                "Sectors": [
+                  54695,
+                  23023
+                ],
+                "Timestamp": 1535182,
+                "Tyre": "SM"
+              },
+              {
+                "BallastKG": 0,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "Cuts": 0,
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "LapTime": 85295,
+                "Restrictor": 0,
+                "Sectors": [
+                  57823,
+                  27472
+                ],
+                "Timestamp": 1542161,
+                "Tyre": "V70"
+              }
+            ],
+            "Result": [
+              {
+                "BallastKG": 0,
+                "BestLap": 66769,
+                "CarId": 6,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "76561198029578060",
+                "DriverName": "Joseph Elton",
+                "Restrictor": 0,
+                "TotalTime": 628012,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 72145,
+                "CarId": 14,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "76561198020046073",
+                "DriverName": "Callum Jones",
+                "Restrictor": 0,
+                "TotalTime": 698358,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 68822,
+                "CarId": 4,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "DriverGuid": "76561198022717360",
+                "DriverName": "namelesssboy",
+                "Restrictor": 0,
+                "TotalTime": 705603,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 73500,
+                "CarId": 0,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "DriverGuid": "76561198074322763",
+                "DriverName": "Seb",
+                "Restrictor": 0,
+                "TotalTime": 628276,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 79571,
+                "CarId": 7,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "76561198055388877",
+                "DriverName": "L33 CR055L3Y",
+                "Restrictor": 0,
+                "TotalTime": 712586,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 1,
+                "CarModel": "a3dr_ferrari_512tr",
+                "DriverGuid": "76561198023931313",
+                "DriverName": "Danny Wilson",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 2,
+                "CarModel": "a3dr_ferrari_512tr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 5,
+                "CarModel": "a3dr_lambo_diablo_vt",
+                "DriverGuid": "76561198045844392",
+                "DriverName": "Spaceman9795",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 8,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 9,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 10,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 3,
+                "CarModel": "a3dr_ferrari_512tr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 12,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 13,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 11,
+                "CarModel": "ks_porsche_911_carrera_rsr",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 15,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 16,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 17,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 18,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 19,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 20,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              },
+              {
+                "BallastKG": 0,
+                "BestLap": 999999999,
+                "CarId": 21,
+                "CarModel": "ks_alfa_33_stradale",
+                "DriverGuid": "",
+                "DriverName": "",
+                "Restrictor": 0,
+                "TotalTime": 0,
+                "HasPenalty": false,
+                "PenaltyTime": 0,
+                "LapPenalty": 0,
+                "Disqualified": false
+              }
+            ],
+            "TrackConfig": "shortcourse",
+            "TrackName": "road_atlanta2018",
+            "Type": "RACE",
+            "Date": "2019-03-02T21:04:00Z",
+            "SessionFile": "2019_3_2_21_4_RACE",
+            "ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+          }
+        }
+      },
+      "StartedTime": "2019-03-02T20:35:23.044261877Z",
+      "CompletedTime": "2019-03-02T21:04:10.636030155Z"
+    },
+    {
+      "ID": "006e6edd-7e77-4d7e-a2ce-d757adb65d95",
+      "RaceSetup": {
+        "Cars": "a3dr_lambo_diablo_vt;ks_porsche_911_carrera_rsr;ks_alfa_33_stradale;a3dr_ferrari_512tr",
+        "Track": "ks_nurburgring",
+        "TrackLayout": "layout_sprint_b",
+        "SunAngle": 0,
+        "LegalTyres": "SM;ST;SV;V70;V",
+        "FuelRate": 100,
+        "DamageMultiplier": 0,
+        "TyreWearRate": 100,
+        "AllowedTyresOut": 3,
+        "ABSAllowed": 1,
+        "TractionControlAllowed": 1,
+        "StabilityControlAllowed": 0,
+        "AutoClutchAllowed": 0,
+        "TyreBlanketsAllowed": 1,
+        "ForceVirtualMirror": 0,
+        "LockedEntryList": 0,
+        "RacePitWindowStart": 0,
+        "RacePitWindowEnd": 0,
+        "ReversedGridRacePositions": 0,
+        "TimeOfDayMultiplier": 0,
+        "QualifyMaxWaitPercentage": 200,
+        "RaceGasPenaltyDisabled": 1,
+        "MaxBallastKilograms": 50,
+        "RaceExtraLap": 0,
+        "PickupModeEnabled": 1,
+        "LoopMode": 1,
+        "MaxClients": 0,
+        "SleepTime": 0,
+        "RaceOverTime": 180,
+        "StartRule": 2,
+        "IsSol": 1,
+        "WindBaseSpeedMin": 3,
+        "WindBaseSpeedMax": 15,
+        "WindBaseDirection": 30,
+        "WindVariationDirection": 15,
+        "DynamicTrack": {
+          "SessionStart": 100,
+          "Randomness": 0,
+          "SessionTransfer": 100,
+          "LapGain": 1
+        },
+        "Sessions": {
+          "QUALIFY": {
+            "Name": "Qualify",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 0
+          },
+          "RACE": {
+            "Name": "Race",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 60
+          }
+        },
+        "Weather": {
+          "WEATHER_0": {
+            "Graphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+            "BaseTemperatureAmbient": 26,
+            "BaseTemperatureRoad": 11,
+            "VariationAmbient": 1,
+            "VariationRoad": 1,
+            "CMGraphics": "sol_01_CLear",
+            "CMWFXType": 15,
+            "CMWFXUseCustomTime": 1,
+            "CMWFXTime": 0,
+            "CMWFXTimeMulti": 15,
+            "CMWFXUseCustomDate": 1,
+            "CMWFXDate": 1530169200,
+            "CMWFXDateUnModified": 1530439200
+          }
+        }
+      },
+      "Sessions": {},
+      "StartedTime": "0001-01-01T00:00:00Z",
+      "CompletedTime": "0001-01-01T00:00:00Z"
+    },
+    {
+      "ID": "c412e271-b3c0-4a71-abbe-954c540260de",
+      "RaceSetup": {
+        "Cars": "a3dr_lambo_diablo_vt;a3dr_ferrari_512tr;ks_porsche_911_carrera_rsr;ks_alfa_33_stradale",
+        "Track": "ks_red_bull_ring",
+        "TrackLayout": "layout_national",
+        "SunAngle": 0,
+        "LegalTyres": "V;SM;ST;SV;V70",
+        "FuelRate": 100,
+        "DamageMultiplier": 0,
+        "TyreWearRate": 100,
+        "AllowedTyresOut": 3,
+        "ABSAllowed": 1,
+        "TractionControlAllowed": 1,
+        "StabilityControlAllowed": 0,
+        "AutoClutchAllowed": 0,
+        "TyreBlanketsAllowed": 1,
+        "ForceVirtualMirror": 0,
+        "LockedEntryList": 0,
+        "RacePitWindowStart": 0,
+        "RacePitWindowEnd": 0,
+        "ReversedGridRacePositions": 0,
+        "TimeOfDayMultiplier": 0,
+        "QualifyMaxWaitPercentage": 200,
+        "RaceGasPenaltyDisabled": 1,
+        "MaxBallastKilograms": 50,
+        "RaceExtraLap": 0,
+        "PickupModeEnabled": 1,
+        "LoopMode": 1,
+        "MaxClients": 0,
+        "SleepTime": 0,
+        "RaceOverTime": 180,
+        "StartRule": 2,
+        "IsSol": 1,
+        "WindBaseSpeedMin": 3,
+        "WindBaseSpeedMax": 15,
+        "WindBaseDirection": 30,
+        "WindVariationDirection": 15,
+        "DynamicTrack": {
+          "SessionStart": 100,
+          "Randomness": 0,
+          "SessionTransfer": 100,
+          "LapGain": 1
+        },
+        "Sessions": {
+          "QUALIFY": {
+            "Name": "Qualify",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 0
+          },
+          "RACE": {
+            "Name": "Race",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 60
+          }
+        },
+        "Weather": {
+          "WEATHER_0": {
+            "Graphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+            "BaseTemperatureAmbient": 26,
+            "BaseTemperatureRoad": 11,
+            "VariationAmbient": 1,
+            "VariationRoad": 1,
+            "CMGraphics": "sol_01_CLear",
+            "CMWFXType": 15,
+            "CMWFXUseCustomTime": 1,
+            "CMWFXTime": 0,
+            "CMWFXTimeMulti": 15,
+            "CMWFXUseCustomDate": 1,
+            "CMWFXDate": 1530190800,
+            "CMWFXDateUnModified": 1530460800
+          }
+        }
+      },
+      "Sessions": {},
+      "StartedTime": "0001-01-01T00:00:00Z",
+      "CompletedTime": "0001-01-01T00:00:00Z"
+    },
+    {
+      "ID": "09bddc04-45ed-40f7-bc94-73a3fe42f3fb",
+      "RaceSetup": {
+        "Cars": "ks_porsche_911_carrera_rsr;ks_alfa_33_stradale;a3dr_lambo_diablo_vt;a3dr_ferrari_512tr",
+        "Track": "suzuka",
+        "TrackLayout": "suzukaeast",
+        "SunAngle": 0,
+        "LegalTyres": "SM;ST;SV;V70;V",
+        "FuelRate": 100,
+        "DamageMultiplier": 0,
+        "TyreWearRate": 100,
+        "AllowedTyresOut": 3,
+        "ABSAllowed": 1,
+        "TractionControlAllowed": 1,
+        "StabilityControlAllowed": 0,
+        "AutoClutchAllowed": 0,
+        "TyreBlanketsAllowed": 1,
+        "ForceVirtualMirror": 0,
+        "LockedEntryList": 0,
+        "RacePitWindowStart": 0,
+        "RacePitWindowEnd": 0,
+        "ReversedGridRacePositions": 0,
+        "TimeOfDayMultiplier": 0,
+        "QualifyMaxWaitPercentage": 200,
+        "RaceGasPenaltyDisabled": 1,
+        "MaxBallastKilograms": 50,
+        "RaceExtraLap": 0,
+        "PickupModeEnabled": 1,
+        "LoopMode": 1,
+        "MaxClients": 0,
+        "SleepTime": 0,
+        "RaceOverTime": 180,
+        "StartRule": 2,
+        "IsSol": 1,
+        "WindBaseSpeedMin": 3,
+        "WindBaseSpeedMax": 15,
+        "WindBaseDirection": 30,
+        "WindVariationDirection": 15,
+        "DynamicTrack": {
+          "SessionStart": 100,
+          "Randomness": 0,
+          "SessionTransfer": 100,
+          "LapGain": 1
+        },
+        "Sessions": {
+          "QUALIFY": {
+            "Name": "Qualify",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 0
+          },
+          "RACE": {
+            "Name": "Race",
+            "Time": 10,
+            "Laps": 0,
+            "IsOpen": 1,
+            "WaitTime": 60
+          }
+        },
+        "Weather": {
+          "WEATHER_0": {
+            "Graphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+            "BaseTemperatureAmbient": 26,
+            "BaseTemperatureRoad": 11,
+            "VariationAmbient": 1,
+            "VariationRoad": 1,
+            "CMGraphics": "sol_01_CLear",
+            "CMWFXType": 15,
+            "CMWFXUseCustomTime": 1,
+            "CMWFXTime": 0,
+            "CMWFXTimeMulti": 15,
+            "CMWFXUseCustomDate": 1,
+            "CMWFXDate": 1530183600,
+            "CMWFXDateUnModified": 1530453600
+          }
+        }
+      },
+      "Sessions": {},
+      "StartedTime": "0001-01-01T00:00:00Z",
+      "CompletedTime": "0001-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/fixtures/open-championship/nurburgring_sprint_b.json
+++ b/fixtures/open-championship/nurburgring_sprint_b.json
@@ -1,0 +1,10112 @@
+[
+  {
+    "Received": "2019-03-02T21:09:08.734788884Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:09.946067478Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 38,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": 1,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:25.40962905Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 12,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:25.585222089Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:26.71112532Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 13,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:30.064192793Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:09:42.196965443Z",
+    "EventType": 58,
+    "Data": 13
+  },
+  {
+    "Received": "2019-03-02T21:09:47.890615937Z",
+    "EventType": 58,
+    "Data": 12
+  },
+  {
+    "Received": "2019-03-02T21:09:49.486432873Z",
+    "EventType": 58,
+    "Data": 14
+  },
+  {
+    "Received": "2019-03-02T21:09:52.948616565Z",
+    "EventType": 58,
+    "Data": 5
+  },
+  {
+    "Received": "2019-03-02T21:11:00.88594501Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:11:31.527147746Z",
+    "EventType": 58,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:11:37.916404489Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 18.542278,
+      "WorldPos": {
+        "X": -5.811005,
+        "Y": 44.792027,
+        "Z": 208.14662
+      },
+      "RelPos": {
+        "X": -0.59411484,
+        "Y": -0.33896056,
+        "Z": 2.3938358
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:11:54.096493651Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 124655,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:12:20.81895975Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 158639,
+      "Cuts": 4,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:12:29.829953127Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 161974,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:12:37.947283571Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 165025,
+      "Cuts": 4,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 124655,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:13:43.982940723Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 109910,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:13:47.040915262Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 135510,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 161974,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:01.805953151Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:11.249870916Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 101436,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:18.53858934Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 117731,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:14:21.102215196Z",
+    "EventType": 58,
+    "Data": 0
+  },
+  {
+    "Received": "2019-03-02T21:14:25.813460758Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 107889,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:15:31.380990763Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 107408,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:15:45.226928009Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 118215,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 101436,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:15:51.513223175Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100259,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:05.78137251Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 107251,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:14.483770848Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 13.080041,
+      "WorldPos": {
+        "X": -145.16048,
+        "Y": 49.746273,
+        "Z": -99.72126
+      },
+      "RelPos": {
+        "X": -0.26772493,
+        "Y": -0.07525219,
+        "Z": 2.4146066
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:17.701675566Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 111879,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:16:20.499658072Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 119417,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:12.248350704Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 5,
+      "ImpactSpeed": 24.277805,
+      "WorldPos": {
+        "X": -23.283201,
+        "Y": 45.699642,
+        "Z": 211.3642
+      },
+      "RelPos": {
+        "X": 0.49153316,
+        "Y": -0.08524662,
+        "Z": 2.2436502
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:12.978825768Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 13,
+      "ImpactSpeed": 29.203583,
+      "WorldPos": {
+        "X": -23.369448,
+        "Y": 45.860977,
+        "Z": 211.21024
+      },
+      "RelPos": {
+        "X": -0.9614358,
+        "Y": 0.0034852177,
+        "Z": 1.0738004
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:16.110338115Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 35.68195,
+      "WorldPos": {
+        "X": 39.42399,
+        "Y": 46.70047,
+        "Z": 221.31882
+      },
+      "RelPos": {
+        "X": 0.44601697,
+        "Y": -0.21971717,
+        "Z": 2.5787513
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:31.112092228Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 7.9172673,
+      "WorldPos": {
+        "X": -42.280933,
+        "Y": 48.00404,
+        "Z": 155.38998
+      },
+      "RelPos": {
+        "X": -1.0371108,
+        "Y": 0.2532033,
+        "Z": -1.0039403
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:31.855180359Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100344,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 135510,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:17:38.856627968Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 113629,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:03.543626417Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 105840,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:22.089315436Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 136306,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:27.451967565Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 176061,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 109910,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:18:57.99758202Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 21.708887,
+      "WorldPos": {
+        "X": 38.94663,
+        "Y": 46.773182,
+        "Z": 227.01897
+      },
+      "RelPos": {
+        "X": -0.753136,
+        "Y": -0.33792946,
+        "Z": 2.3337514
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:19:11.586534351Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 12,
+      "ImpactSpeed": 31.520313,
+      "WorldPos": {
+        "X": -198.21608,
+        "Y": 48.933544,
+        "Z": -720.9078
+      },
+      "RelPos": {
+        "X": 0.96808124,
+        "Y": -0.026201695,
+        "Z": -1.772821
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:19:12.945129978Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 4,
+      "ImpactSpeed": 29.42692,
+      "WorldPos": {
+        "X": -197.96587,
+        "Y": 48.91487,
+        "Z": -720.9955
+      },
+      "RelPos": {
+        "X": -0.7714559,
+        "Y": 0.031207465,
+        "Z": 2.1077843
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:19:55.740574622Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:20:15.382669917Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 107932,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 107932,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:20:20.820527052Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T21:20:21.798630421Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 119701,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 100259,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 105840,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 107251,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 107932,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 113629,
+          "Laps": 2,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:20:30.94914187Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:21:51.782855833Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_21_21_QUALIFY.json"
+  },
+  {
+    "Received": "2019-03-02T21:21:51.790896572Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 1,
+      "CurrentSessionIndex": 1,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Race",
+      "Type": 3,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 60000,
+      "AmbientTemp": 26,
+      "RoadTemp": 36,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": -59999,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:12.317883515Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 12,
+      "ImpactSpeed": 39.094646,
+      "WorldPos": {
+        "X": -19.93755,
+        "Y": 53.62102,
+        "Z": -145.9279
+      },
+      "RelPos": {
+        "X": 0.22046942,
+        "Y": 0.028909057,
+        "Z": 2.290286
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:13.325697875Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 13,
+      "ImpactSpeed": 39.90537,
+      "WorldPos": {
+        "X": -19.930222,
+        "Y": 53.621746,
+        "Z": -146.01479
+      },
+      "RelPos": {
+        "X": 0.41375586,
+        "Y": -0.09921125,
+        "Z": -1.911791
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:16.634355568Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 14,
+      "ImpactSpeed": 11.875026,
+      "WorldPos": {
+        "X": -42.159172,
+        "Y": 52.01675,
+        "Z": -121.81439
+      },
+      "RelPos": {
+        "X": -0.92850596,
+        "Y": 0.10343917,
+        "Z": 1.7762165
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:19.573930329Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 4,
+      "ImpactSpeed": 6.9451966,
+      "WorldPos": {
+        "X": -42.188473,
+        "Y": 52.019783,
+        "Z": -121.7854
+      },
+      "RelPos": {
+        "X": 0.8708201,
+        "Y": 0.19308236,
+        "Z": -0.77723074
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:31.639069275Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 13,
+      "ImpactSpeed": 9.566836,
+      "WorldPos": {
+        "X": -214.78761,
+        "Y": 54.420834,
+        "Z": -237.52522
+      },
+      "RelPos": {
+        "X": -0.51635367,
+        "Y": -0.014088921,
+        "Z": -1.9858334
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:23:32.31934472Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 4,
+      "ImpactSpeed": 10.870226,
+      "WorldPos": {
+        "X": -214.86636,
+        "Y": 54.44567,
+        "Z": -237.40239
+      },
+      "RelPos": {
+        "X": 0.38947755,
+        "Y": 0.03497096,
+        "Z": 2.274087
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:41.8670442Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 110073,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:47.590196034Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 115799,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:48.342537196Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 13,
+      "ImpactSpeed": 14.794508,
+      "WorldPos": {
+        "X": -8.549445,
+        "Y": 65.1321,
+        "Z": -919.04645
+      },
+      "RelPos": {
+        "X": 0.84590185,
+        "Y": 0.12969741,
+        "Z": 1.8989832
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:49.941140373Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 118114,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:51.652789158Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 13,
+      "ImpactSpeed": 27.207985,
+      "WorldPos": {
+        "X": -5.5134254,
+        "Y": 64.94286,
+        "Z": -930.2989
+      },
+      "RelPos": {
+        "X": -0.74266434,
+        "Y": -0.28352273,
+        "Z": 2.323432
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:51.984843782Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 120158,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:51.995005656Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 120161,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:52.336873446Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 4,
+      "ImpactSpeed": 21.892897,
+      "WorldPos": {
+        "X": -5.5154567,
+        "Y": 64.94241,
+        "Z": -929.9571
+      },
+      "RelPos": {
+        "X": 0.84947836,
+        "Y": -0.2639276,
+        "Z": 0.82611984
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:52.342208326Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 12,
+      "ImpactSpeed": 13.813642,
+      "WorldPos": {
+        "X": -8.53854,
+        "Y": 65.14362,
+        "Z": -918.94727
+      },
+      "RelPos": {
+        "X": -0.9053652,
+        "Y": 0.10593543,
+        "Z": 1.1134826
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:24:56.655350923Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 4,
+      "ImpactSpeed": 35.86649,
+      "WorldPos": {
+        "X": -16.960098,
+        "Y": 64.44094,
+        "Z": -846.7903
+      },
+      "RelPos": {
+        "X": -1.0029845,
+        "Y": 0.11470459,
+        "Z": -1.8480765
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:25:06.321726273Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 134493,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 110068,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:28.167864284Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 106289,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:34.643463219Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 102688,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 115796,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:34.691817913Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 107089,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 118105,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:36.484935701Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 106557,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 120154,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:41.840029103Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 109870,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 134491,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:26:58.429992038Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 112135,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 216354,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:27:43.235749778Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:07.307795538Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T21:28:10.909115515Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 102764,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 222840,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:15.52787769Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100882,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 222885,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:21.038521458Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 106363,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 224667,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:25.589013499Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 109084,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 230021,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:27.3620387Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 105544,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 246623,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:28:51.292551646Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 112861,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 319115,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:29:54.366276256Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 103458,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 323718,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:29:55.819597543Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 100301,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 329249,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:10.973549653Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 109931,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 333753,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:12.301639178Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 106705,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 335563,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:13.029891377Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 105675,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 359483,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:30:44.240667594Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 112947,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:10.749577416Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 183587,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 424017,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:37.823635048Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 101999,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 422572,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:39.800013977Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 105407,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 439178,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:56.611077093Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 105635,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 441237,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:31:59.776719348Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 106721,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 440466,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:06.219925037Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 113950,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 472429,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:40.162852974Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:50.440807667Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 126220,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 498880,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:54.037907605Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 103268,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 526016,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:32:59.302912029Z",
+    "EventType": 58,
+    "Data": 2
+  },
+  {
+    "Received": "2019-03-02T21:33:19.523177622Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 12,
+      "LapTime": 101684,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 527976,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:23.567900834Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 103799,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 544812,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:40.937569172Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 104290,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 554405,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:51.568194754Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 105328,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 547954,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:58.913204593Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 12,
+      "Message": "guys were doing 2 more races"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:33:59.113532448Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 13,
+      "LapTime": 119343,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 667296,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 602164,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:12.443906157Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 13,
+      "ImpactSpeed": 12.134497,
+      "WorldPos": {
+        "X": -15.206701,
+        "Y": 62.505207,
+        "Z": -570.23676
+      },
+      "RelPos": {
+        "X": -0.000015616417,
+        "Y": 0.021000223,
+        "Z": 2.3114586
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:17.102091228Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 12,
+      "Message": "rejoin after we're done"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:17.44586817Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 13,
+      "ImpactSpeed": 0.040641572,
+      "WorldPos": {
+        "X": -15.211935,
+        "Y": 62.52244,
+        "Z": -570.2432
+      },
+      "RelPos": {
+        "X": 0.00004470721,
+        "Y": 0.021001603,
+        "Z": 2.3114588
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:18.176682022Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 2,
+      "ImpactSpeed": 17.414568,
+      "WorldPos": {
+        "X": -54.911613,
+        "Y": 50.592987,
+        "Z": -136.20073
+      },
+      "RelPos": {
+        "X": -0.74025893,
+        "Y": -0.2762671,
+        "Z": 2.3216436
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:19.133157669Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 5,
+      "ImpactSpeed": 5.37176,
+      "WorldPos": {
+        "X": -55.406406,
+        "Y": 50.88729,
+        "Z": -136.00749
+      },
+      "RelPos": {
+        "X": -0.7681393,
+        "Y": 0.10559672,
+        "Z": 2.3771882
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:28.178539412Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 13.651996,
+      "WorldPos": {
+        "X": -90.244736,
+        "Y": 51.62519,
+        "Z": -109.31307
+      },
+      "RelPos": {
+        "X": -1.0029707,
+        "Y": 0.11470359,
+        "Z": -1.8480778
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:29.714834669Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 12,
+      "ImpactSpeed": 32.78987,
+      "WorldPos": {
+        "X": -16.758085,
+        "Y": 52.92172,
+        "Z": -114.36712
+      },
+      "RelPos": {
+        "X": 0.55451196,
+        "Y": -0.0042012604,
+        "Z": 2.2253792
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:33.453379987Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 14,
+      "ImpactSpeed": 30.0817,
+      "WorldPos": {
+        "X": -16.459616,
+        "Y": 52.920013,
+        "Z": -114.3293
+      },
+      "RelPos": {
+        "X": 0.5017414,
+        "Y": -0.06312472,
+        "Z": 2.2547133
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:34.713202554Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 12,
+      "ImpactSpeed": 0.94562477,
+      "WorldPos": {
+        "X": -16.974226,
+        "Y": 53.062443,
+        "Z": -119.982956
+      },
+      "RelPos": {
+        "X": 0.82526594,
+        "Y": 0.14744733,
+        "Z": 1.2387986
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:36.885406991Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 102841,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 667296,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 598647,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 704985,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:38.176716114Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 19.176018,
+      "WorldPos": {
+        "X": -74.927986,
+        "Y": 51.397366,
+        "Z": -78.0888
+      },
+      "RelPos": {
+        "X": 0.7531431,
+        "Y": -0.33792782,
+        "Z": 2.3337522
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:42.451774653Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 12,
+      "ImpactSpeed": 187.16333,
+      "WorldPos": {
+        "X": -22.737139,
+        "Y": 52.814323,
+        "Z": -127.11853
+      },
+      "RelPos": {
+        "X": 0.006248802,
+        "Y": 0.0312353,
+        "Z": 2.249955
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:43.454523451Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 12,
+      "OtherCarID": 13,
+      "ImpactSpeed": 184.43976,
+      "WorldPos": {
+        "X": -23.148249,
+        "Y": 52.79676,
+        "Z": -127.258995
+      },
+      "RelPos": {
+        "X": 0.7301203,
+        "Y": -0.011246234,
+        "Z": -1.6173282
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:44.714254272Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 45.27735,
+      "WorldPos": {
+        "X": -44.370247,
+        "Y": 52.011753,
+        "Z": -138.8188
+      },
+      "RelPos": {
+        "X": -0.26772702,
+        "Y": -0.07525219,
+        "Z": 2.414605
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:48.179913209Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 53.624336,
+      "WorldPos": {
+        "X": -61.591385,
+        "Y": 50.963203,
+        "Z": -152.75276
+      },
+      "RelPos": {
+        "X": 0.48310763,
+        "Y": 0.07986483,
+        "Z": -2.0333033
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:48.188891233Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 2,
+      "ImpactSpeed": 31.693771,
+      "WorldPos": {
+        "X": -66.4052,
+        "Y": 50.33559,
+        "Z": -153.84962
+      },
+      "RelPos": {
+        "X": -0.90373546,
+        "Y": -0.28399107,
+        "Z": 1.8751855
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:49.151927622Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 5,
+      "ImpactSpeed": 14.6790905,
+      "WorldPos": {
+        "X": -66.41498,
+        "Y": 50.673813,
+        "Z": -153.91437
+      },
+      "RelPos": {
+        "X": -0.41335326,
+        "Y": 0.078642935,
+        "Z": 2.518771
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:34:53.184277299Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 2,
+      "ImpactSpeed": 8.233119,
+      "WorldPos": {
+        "X": -66.56751,
+        "Y": 50.337013,
+        "Z": -153.97296
+      },
+      "RelPos": {
+        "X": -0.88833475,
+        "Y": -0.26712742,
+        "Z": 1.2227057
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:02.231923377Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 5,
+      "ImpactSpeed": 16.817375,
+      "WorldPos": {
+        "X": -44.250366,
+        "Y": 52.076973,
+        "Z": -100.73863
+      },
+      "RelPos": {
+        "X": -1.0005605,
+        "Y": 0.10572691,
+        "Z": -1.8457379
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:03.181082997Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 1,
+      "ImpactSpeed": 34.61637,
+      "WorldPos": {
+        "X": -44.299366,
+        "Y": 52.05592,
+        "Z": -100.77864
+      },
+      "RelPos": {
+        "X": 0.933162,
+        "Y": 0.11160381,
+        "Z": -1.8497572
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:08.265055924Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 4,
+      "LapTime": 137827,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 12,
+          "LapTime": 627696,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 631771,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 649102,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 659741,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 13,
+          "LapTime": 667296,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 4,
+          "LapTime": 736471,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 704985,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:26.775001242Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 13,
+      "ImpactSpeed": 219.55276,
+      "WorldPos": {
+        "X": -39.82771,
+        "Y": 51.736614,
+        "Z": -102.340126
+      },
+      "RelPos": {
+        "X": -0.7531392,
+        "Y": -0.3379298,
+        "Z": 2.3337488
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:26.782511838Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 5,
+      "ImpactSpeed": 129.94574,
+      "WorldPos": {
+        "X": -42.05288,
+        "Y": 52.53081,
+        "Z": -83.71655
+      },
+      "RelPos": {
+        "X": -0.94686234,
+        "Y": -0.34824842,
+        "Z": -0.18666974
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:27.455413832Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 13,
+      "OtherCarID": 4,
+      "ImpactSpeed": 199.72864,
+      "WorldPos": {
+        "X": -39.530144,
+        "Y": 51.750984,
+        "Z": -101.89521
+      },
+      "RelPos": {
+        "X": -0.8575623,
+        "Y": -0.28563473,
+        "Z": 1.1882828
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:28.188898025Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 4,
+      "ImpactSpeed": 110.92213,
+      "WorldPos": {
+        "X": -42.353203,
+        "Y": 52.46694,
+        "Z": -84.10977
+      },
+      "RelPos": {
+        "X": -1.0488393,
+        "Y": 0.36228293,
+        "Z": 1.0086184
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:31.777922442Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 4,
+      "ImpactSpeed": 63.873837,
+      "WorldPos": {
+        "X": -47.30218,
+        "Y": 52.52619,
+        "Z": -35.677143
+      },
+      "RelPos": {
+        "X": -0.90399927,
+        "Y": -0.33399916,
+        "Z": 1.4163027
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:32.455782604Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 13,
+      "ImpactSpeed": 51.10822,
+      "WorldPos": {
+        "X": -64.56666,
+        "Y": 52.30019,
+        "Z": -55.46193
+      },
+      "RelPos": {
+        "X": -0.4754461,
+        "Y": 0.4388718,
+        "Z": -2.061699
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:54.728434728Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 0,
+      "ImpactSpeed": 6.6961966,
+      "WorldPos": {
+        "X": -69.785225,
+        "Y": 50.862392,
+        "Z": -136.48183
+      },
+      "RelPos": {
+        "X": -0.8436349,
+        "Y": 0.093440555,
+        "Z": -0.18212335
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:56.343916512Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 14,
+      "ImpactSpeed": 6.637684,
+      "WorldPos": {
+        "X": -69.78588,
+        "Y": 50.86696,
+        "Z": -136.48225
+      },
+      "RelPos": {
+        "X": 0.7859641,
+        "Y": 0.11970091,
+        "Z": 2.4330487
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:58.196176483Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 27.822073,
+      "WorldPos": {
+        "X": -151.89566,
+        "Y": 54.182297,
+        "Z": -233.62479
+      },
+      "RelPos": {
+        "X": 0.98289543,
+        "Y": 0.11470422,
+        "Z": -1.848078
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:35:59.729729538Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 16.162987,
+      "WorldPos": {
+        "X": -61.42354,
+        "Y": 50.71328,
+        "Z": -152.38422
+      },
+      "RelPos": {
+        "X": -0.5547012,
+        "Y": -0.0042031445,
+        "Z": 2.2253718
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:09.729883725Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 4,
+      "ImpactSpeed": 2.6417935,
+      "WorldPos": {
+        "X": -63.21272,
+        "Y": 50.654316,
+        "Z": -141.74022
+      },
+      "RelPos": {
+        "X": 0.82790667,
+        "Y": 0.026703224,
+        "Z": -1.2146415
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:11.347366397Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 10.097206,
+      "WorldPos": {
+        "X": -71.57716,
+        "Y": 50.56206,
+        "Z": -171.44257
+      },
+      "RelPos": {
+        "X": 0.4050244,
+        "Y": -0.26062438,
+        "Z": 2.598421
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:11.78777821Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 4,
+      "OtherCarID": 14,
+      "ImpactSpeed": 2.6076248,
+      "WorldPos": {
+        "X": -63.210712,
+        "Y": 50.668953,
+        "Z": -141.75197
+      },
+      "RelPos": {
+        "X": -1.0112256,
+        "Y": -0.003489851,
+        "Z": -1.0055783
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:25.977489149Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 12,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:26.785353183Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 4,
+      "ImpactSpeed": 15.688271,
+      "WorldPos": {
+        "X": -73.63849,
+        "Y": 50.600716,
+        "Z": -175.89908
+      },
+      "RelPos": {
+        "X": 0.5762212,
+        "Y": -0.33907554,
+        "Z": 2.4005952
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:26.915915616Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:27.807126494Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 13,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:28.598028354Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:29.313277776Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:33.270198718Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:35.032681175Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:40.387347494Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:36:40.400084037Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_21_36_RACE.json"
+  }
+]

--- a/fixtures/open-championship/rbr_national.json
+++ b/fixtures/open-championship/rbr_national.json
@@ -1,0 +1,23531 @@
+[
+  {
+    "Received": "2019-03-02T21:36:40.401223435Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_nurburgring",
+      "TrackConfig": "layout_sprint_b",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 25,
+      "RoadTemp": 36,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530169200",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:12.042904371Z",
+    "EventType": 56,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:37:12.052989971Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:13.263909557Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 36,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:21.088246367Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:24.317108463Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 7,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:25.999885344Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:27.97710064Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:31.866812414Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 19,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:37.576238697Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 8,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:37.999876104Z",
+    "EventType": 58,
+    "Data": 5
+  },
+  {
+    "Received": "2019-03-02T21:37:40.877808024Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:37:45.758348344Z",
+    "EventType": 58,
+    "Data": 7
+  },
+  {
+    "Received": "2019-03-02T21:37:51.251522766Z",
+    "EventType": 58,
+    "Data": 19
+  },
+  {
+    "Received": "2019-03-02T21:37:51.865407588Z",
+    "EventType": 58,
+    "Data": 8
+  },
+  {
+    "Received": "2019-03-02T21:37:51.945899126Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T21:37:53.022582709Z",
+    "EventType": 58,
+    "Data": 2
+  },
+  {
+    "Received": "2019-03-02T21:37:57.173376601Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 6,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:11.539169666Z",
+    "EventType": 58,
+    "Data": 0
+  },
+  {
+    "Received": "2019-03-02T21:38:17.606616501Z",
+    "EventType": 58,
+    "Data": 6
+  },
+  {
+    "Received": "2019-03-02T21:38:20.457285067Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 19,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:22.999182262Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 3.4596066,
+      "WorldPos": {
+        "X": -82.11017,
+        "Y": 5.2242184,
+        "Z": 372.9922
+      },
+      "RelPos": {
+        "X": 1.06182,
+        "Y": 0.42115015,
+        "Z": 0.78120726
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:39.21786618Z",
+    "EventType": 58,
+    "Data": 19
+  },
+  {
+    "Received": "2019-03-02T21:38:47.455807272Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 6,
+      "ImpactSpeed": 18.330818,
+      "WorldPos": {
+        "X": -85.2096,
+        "Y": 5.2810855,
+        "Z": 354.99478
+      },
+      "RelPos": {
+        "X": -0.9588042,
+        "Y": -0.119409926,
+        "Z": -1.0309438
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:38:50.191630362Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 72374,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:15.845102598Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 90131,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:19.965825514Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 88125,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:22.799399419Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 89754,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:31.866791633Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 2,
+      "ImpactSpeed": 23.515629,
+      "WorldPos": {
+        "X": -88.74069,
+        "Y": 4.919533,
+        "Z": 382.33865
+      },
+      "RelPos": {
+        "X": -0.27980423,
+        "Y": -0.10858263,
+        "Z": -1.9046298
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:32.46578278Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 6,
+      "ImpactSpeed": 46.403378,
+      "WorldPos": {
+        "X": 671.3677,
+        "Y": 2.49896,
+        "Z": 68.04241
+      },
+      "RelPos": {
+        "X": -0.960501,
+        "Y": -0.2639836,
+        "Z": -1.0496056
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:33.012572911Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 8,
+      "ImpactSpeed": 31.24352,
+      "WorldPos": {
+        "X": -88.741135,
+        "Y": 4.9266987,
+        "Z": 382.29172
+      },
+      "RelPos": {
+        "X": -0.40420747,
+        "Y": -0.13817638,
+        "Z": 2.5619392
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:36.467611533Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 6,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:37.704868147Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 86194,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:44.769792181Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 112866,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:48.000320297Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:50.75586255Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 60545,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 90131,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:39:58.118103566Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:02.780953742Z",
+    "EventType": 58,
+    "Data": 14
+  },
+  {
+    "Received": "2019-03-02T21:40:12.8362812Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 44.08058,
+      "WorldPos": {
+        "X": -252.87401,
+        "Y": 7.892081,
+        "Z": 28.513966
+      },
+      "RelPos": {
+        "X": 0.7531396,
+        "Y": -0.25777528,
+        "Z": 2.4668858
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:14.057404003Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58197,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:16.961706846Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 97755,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:19.682293816Z",
+    "EventType": 58,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T21:40:29.744855011Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 4,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Blu_Oscuro",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:35.164444927Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 75167,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:36.537248177Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 53.941162,
+      "WorldPos": {
+        "X": 639.5377,
+        "Y": -6.4124155,
+        "Z": 155.32301
+      },
+      "RelPos": {
+        "X": 0.40504396,
+        "Y": -0.3401828,
+        "Z": 2.4652991
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:36.625941453Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 15,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:41.804368845Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Giallo_Modena",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:41.925393449Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 8.076889,
+      "WorldPos": {
+        "X": 550.0641,
+        "Y": -8.876603,
+        "Z": 224.56955
+      },
+      "RelPos": {
+        "X": 1.0618303,
+        "Y": 0.36228234,
+        "Z": 1.0086217
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:43.029374671Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 8.968531,
+      "WorldPos": {
+        "X": 550.2631,
+        "Y": -8.875664,
+        "Z": 224.5125
+      },
+      "RelPos": {
+        "X": -1.0273305,
+        "Y": 0.34762108,
+        "Z": 0.64361054
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:46.748824939Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 61987,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:47.067101882Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 84307,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:54.82806554Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 77122,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:40:56.811447454Z",
+    "EventType": 58,
+    "Data": 15
+  },
+  {
+    "Received": "2019-03-02T21:41:01.227480518Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "01_racing_red",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:13.129828498Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59089,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 97755,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:13.790468015Z",
+    "EventType": 58,
+    "Data": 9
+  },
+  {
+    "Received": "2019-03-02T21:41:19.273791578Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62297,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:21.54335546Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 19.087461,
+      "WorldPos": {
+        "X": -253.11035,
+        "Y": 8.347797,
+        "Z": 28.379944
+      },
+      "RelPos": {
+        "X": -1.002975,
+        "Y": 0.11470608,
+        "Z": -1.8480747
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:37.924142682Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 62777,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:40.06565081Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 97444,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:47.815155756Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 60756,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:41:50.234303894Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 63447,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:11.081877963Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 76245,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:12.171722336Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59023,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:22.052562909Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62804,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:34.688202542Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 81073,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:40.417845412Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60360,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:42.44191057Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "01_racing_red",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:44.492010146Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 66585,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:49.384395917Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 61564,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:50.734536155Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 60538,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:42:57.803499333Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 16,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:10.142847533Z",
+    "EventType": 58,
+    "Data": 16
+  },
+  {
+    "Received": "2019-03-02T21:43:10.725014144Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58577,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 86194,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:13.192690034Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 62081,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:26.971947748Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 64910,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:50.360853631Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 65871,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:55.140272378Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64400,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:55.773105746Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 2,
+      "ImpactSpeed": 61.071697,
+      "WorldPos": {
+        "X": 631.898,
+        "Y": 3.1410034,
+        "Z": 37.97196
+      },
+      "RelPos": {
+        "X": 0.9197418,
+        "Y": -0.25077108,
+        "Z": -1.2273545
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:43:58.075047209Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 7,
+      "ImpactSpeed": 53.444782,
+      "WorldPos": {
+        "X": 631.8672,
+        "Y": 3.1153967,
+        "Z": 38.224266
+      },
+      "RelPos": {
+        "X": 0.0053220987,
+        "Y": -0.25576723,
+        "Z": 2.633796
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:14.802048337Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 64087,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:16.257862202Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 86847,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:17.594823242Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 64433,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:21.755704201Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 204899,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 62297,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:21.964037832Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 70.24515,
+      "WorldPos": {
+        "X": -262.906,
+        "Y": 8.518117,
+        "Z": 22.781559
+      },
+      "RelPos": {
+        "X": 0.40501606,
+        "Y": -0.34018025,
+        "Z": 2.4652996
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:28.846121225Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 61859,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:39.264262197Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 4.6203675,
+      "WorldPos": {
+        "X": -83.12829,
+        "Y": 5.112513,
+        "Z": 371.9643
+      },
+      "RelPos": {
+        "X": 0.6354965,
+        "Y": 0.2201055,
+        "Z": -1.4963211
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:41.598870122Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 91621,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 62777,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:51.019823924Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 60655,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:51.972614169Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 29.39239,
+      "WorldPos": {
+        "X": 67.01412,
+        "Y": 3.1010642,
+        "Z": -20.582636
+      },
+      "RelPos": {
+        "X": -0.03949946,
+        "Y": -0.115679756,
+        "Z": -2.0003524
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:44:53.080706406Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 26.648136,
+      "WorldPos": {
+        "X": 67.16325,
+        "Y": 3.049012,
+        "Z": -20.813665
+      },
+      "RelPos": {
+        "X": -0.23387921,
+        "Y": -0.06850241,
+        "Z": 2.5451326
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:05.94307614Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 145516,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:19.270203316Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 7.2500153,
+      "WorldPos": {
+        "X": 141.04803,
+        "Y": -11.764014,
+        "Z": 333.6731
+      },
+      "RelPos": {
+        "X": 0.81933147,
+        "Y": 0.2769497,
+        "Z": 1.2484288
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:20.267405448Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 65458,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:21.593280586Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 28.949938,
+      "WorldPos": {
+        "X": 528.66394,
+        "Y": -9.399206,
+        "Z": 248.89313
+      },
+      "RelPos": {
+        "X": -0.40499365,
+        "Y": -0.34018284,
+        "Z": 2.4653058
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:23.334978124Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 67099,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:29.272843555Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 4.3917828,
+      "WorldPos": {
+        "X": 61.724037,
+        "Y": -7.701953,
+        "Z": 352.9893
+      },
+      "RelPos": {
+        "X": -0.76444626,
+        "Y": 0.27832356,
+        "Z": 1.8490113
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:37.369323134Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 79792,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:42.379294662Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 107237,
+      "Cuts": 5,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:42.640469459Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 61057,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:45:52.33667028Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61322,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:06.530822678Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60567,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:11.986567684Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 40.87872,
+      "WorldPos": {
+        "X": -256.5494,
+        "Y": 8.090948,
+        "Z": 26.381516
+      },
+      "RelPos": {
+        "X": 0.7531419,
+        "Y": -0.33792984,
+        "Z": 2.3337407
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:18.557376359Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58299,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 61564,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:23.250839151Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 59878,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:42.653462814Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 65278,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:47.466646247Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 64823,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:49.453577914Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 140614,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:54.71142528Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 62373,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:56.235453151Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 73848,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:46:59.291423305Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 15.448443,
+      "WorldPos": {
+        "X": -76.54756,
+        "Y": 3.9989588,
+        "Z": 383.15363
+      },
+      "RelPos": {
+        "X": -0.2677287,
+        "Y": -0.075251,
+        "Z": 2.414592
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:07.010705399Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60516,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:30.70315599Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 189021,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 189021,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:46.515471681Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63815,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 189021,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:47:57.37479123Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 61137,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 58197,
+          "Laps": 6,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 59878,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 60360,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 60655,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61137,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 61859,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 62081,
+          "Laps": 4,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 72374,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 91621,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 189021,
+          "Laps": 1,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:01.633585484Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 6.5178733,
+      "WorldPos": {
+        "X": -111.53546,
+        "Y": 7.343877,
+        "Z": 430.43973
+      },
+      "RelPos": {
+        "X": -0.78594345,
+        "Y": 0.039387245,
+        "Z": 2.2981675
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:02.687605661Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 54.973114,
+      "WorldPos": {
+        "X": 545.8572,
+        "Y": -8.688885,
+        "Z": 245.48264
+      },
+      "RelPos": {
+        "X": 0.7771702,
+        "Y": -0.045661706,
+        "Z": -1.382614
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:07.691151235Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 13.51755,
+      "WorldPos": {
+        "X": 441.8475,
+        "Y": -10.812998,
+        "Z": 248.50237
+      },
+      "RelPos": {
+        "X": 0.635494,
+        "Y": 0.22010534,
+        "Z": -1.496328
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:11.623086952Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 8,
+      "ImpactSpeed": 102.47527,
+      "WorldPos": {
+        "X": -75.59137,
+        "Y": 3.873283,
+        "Z": 405.27777
+      },
+      "RelPos": {
+        "X": 0.93286204,
+        "Y": 0.0018701442,
+        "Z": 1.7754714
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:11.632012452Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 33.73157,
+      "WorldPos": {
+        "X": -61.859505,
+        "Y": 2.915883,
+        "Z": 416.17844
+      },
+      "RelPos": {
+        "X": -0.0000042915344,
+        "Y": -0.3396025,
+        "Z": 2.5021923
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:11.956655004Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 0,
+      "ImpactSpeed": 111.832794,
+      "WorldPos": {
+        "X": -75.494484,
+        "Y": 3.6153605,
+        "Z": 405.2506
+      },
+      "RelPos": {
+        "X": 0.48650712,
+        "Y": -0.18413615,
+        "Z": 2.2361999
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:12.693510146Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 14,
+      "ImpactSpeed": 1.229967,
+      "WorldPos": {
+        "X": 441.54178,
+        "Y": -11.340387,
+        "Z": 248.60202
+      },
+      "RelPos": {
+        "X": 0.293173,
+        "Y": -0.3017311,
+        "Z": -1.4648188
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:15.822303853Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 22.237503,
+      "WorldPos": {
+        "X": 597.1134,
+        "Y": -8.620743,
+        "Z": 192.36179
+      },
+      "RelPos": {
+        "X": 0.5137629,
+        "Y": 0.03942673,
+        "Z": 2.2621512
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:30.017572922Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 16,
+      "OtherCarID": 14,
+      "ImpactSpeed": 72.806984,
+      "WorldPos": {
+        "X": 51.212345,
+        "Y": -6.94435,
+        "Z": 366.27838
+      },
+      "RelPos": {
+        "X": 0.38887668,
+        "Y": -0.13965902,
+        "Z": 2.298734
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:48:32.691892556Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 16,
+      "ImpactSpeed": 91.31936,
+      "WorldPos": {
+        "X": 51.064587,
+        "Y": -6.870232,
+        "Z": 366.06497
+      },
+      "RelPos": {
+        "X": 0.12476914,
+        "Y": -0.16057822,
+        "Z": -1.3349594
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:11.171456455Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "hi"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:18.94285641Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "sup"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:28.46085895Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "missmatch with mods god noes why"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:31.720873494Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "r u from discord"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:38.047937297Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "it was update4d today"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:45.973302403Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 0,
+      "Message": "no. im from niferia"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:49.465529433Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "ohhh ok"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:55.416685396Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_21_49_QUALIFY.json"
+  },
+  {
+    "Received": "2019-03-02T21:49:55.441734491Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 1,
+      "CurrentSessionIndex": 1,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Race",
+      "Type": 3,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 60000,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": -59999,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T21:49:57.340095184Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 0,
+      "Message": "wakanda forever"
+    }
+  },
+  {
+    "Received": "2019-03-02T21:51:26.764736308Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 60.151325,
+      "WorldPos": {
+        "X": -261.67056,
+        "Y": 8.919584,
+        "Z": 23.479906
+      },
+      "RelPos": {
+        "X": 0.8929572,
+        "Y": 0.19191818,
+        "Z": 1.7670182
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:51:30.055123019Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 16,
+      "OtherCarID": 0,
+      "ImpactSpeed": 0.7579006,
+      "WorldPos": {
+        "X": -189.51445,
+        "Y": 3.5808847,
+        "Z": 42.479992
+      },
+      "RelPos": {
+        "X": 0.8338914,
+        "Y": 0.03970459,
+        "Z": -1.1850265
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:51:31.67389167Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 16,
+      "ImpactSpeed": 7.2466393,
+      "WorldPos": {
+        "X": -189.5225,
+        "Y": 3.5618987,
+        "Z": 42.53072
+      },
+      "RelPos": {
+        "X": -0.788803,
+        "Y": -0.051797982,
+        "Z": 2.2685122
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:01.74010634Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 66304,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:02.363781653Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 66938,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:03.675724455Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 68157,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:05.829476682Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 70399,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:05.977352238Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 70457,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:06.860480958Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 71391,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:08.457320299Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 73011,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:17.630949935Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 82204,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:17.840056083Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 82384,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 68157,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:22.058982045Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 19.164434,
+      "WorldPos": {
+        "X": -274.1923,
+        "Y": 7.5828037,
+        "Z": 113.08818
+      },
+      "RelPos": {
+        "X": 0.8488104,
+        "Y": -0.18180327,
+        "Z": 2.0543165
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:23.177133578Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 19.685852,
+      "WorldPos": {
+        "X": -274.1873,
+        "Y": 7.8141065,
+        "Z": 113.03572
+      },
+      "RelPos": {
+        "X": -0.98529994,
+        "Y": -0.074490674,
+        "Z": -1.2714918
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:27.065942203Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 2,
+      "ImpactSpeed": 19.95239,
+      "WorldPos": {
+        "X": -269.58817,
+        "Y": 9.283741,
+        "Z": 23.860826
+      },
+      "RelPos": {
+        "X": -1.0029825,
+        "Y": 0.11470597,
+        "Z": -1.8480824
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:27.080593643Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 5.5364323,
+      "WorldPos": {
+        "X": -268.29575,
+        "Y": 9.324921,
+        "Z": 19.706554
+      },
+      "RelPos": {
+        "X": 0.9828891,
+        "Y": 0.11470581,
+        "Z": -1.8480811
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:28.176200387Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 1,
+      "ImpactSpeed": 24.19631,
+      "WorldPos": {
+        "X": -269.55066,
+        "Y": 9.279741,
+        "Z": 23.914267
+      },
+      "RelPos": {
+        "X": -0.9584526,
+        "Y": 0.07306049,
+        "Z": -1.407486
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:28.182408274Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 24.952705,
+      "WorldPos": {
+        "X": -267.67563,
+        "Y": 9.2146,
+        "Z": 20.068031
+      },
+      "RelPos": {
+        "X": 0.78597134,
+        "Y": 0.11969936,
+        "Z": 2.4330282
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:34.362849203Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 8.50892,
+      "WorldPos": {
+        "X": -260.52338,
+        "Y": 7.8806734,
+        "Z": 60.956448
+      },
+      "RelPos": {
+        "X": -0.26773274,
+        "Y": -0.07525164,
+        "Z": 2.4145794
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:44.36651367Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 19,
+      "OtherCarID": 0,
+      "ImpactSpeed": 11.218829,
+      "WorldPos": {
+        "X": -192.88681,
+        "Y": 3.9854534,
+        "Z": 39.799446
+      },
+      "RelPos": {
+        "X": 0.8175962,
+        "Y": 0.2386778,
+        "Z": 1.2449865
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:46.680055822Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 19,
+      "ImpactSpeed": 26.766272,
+      "WorldPos": {
+        "X": -163.28918,
+        "Y": 1.9320467,
+        "Z": 66.846756
+      },
+      "RelPos": {
+        "X": -0.98438007,
+        "Y": 0.15120523,
+        "Z": 0.4913641
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:52:49.365443729Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 19,
+      "OtherCarID": 0,
+      "ImpactSpeed": 24.419199,
+      "WorldPos": {
+        "X": -163.20607,
+        "Y": 1.934947,
+        "Z": 66.939926
+      },
+      "RelPos": {
+        "X": 0.76426,
+        "Y": 0.27832302,
+        "Z": 1.8490052
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:03.071984987Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59391,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 70393,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:04.189151987Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58339,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 71399,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:07.24471117Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60398,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 70456,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:08.62294695Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 62661,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 66306,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:10.492109795Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 68114,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:10.50424228Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 68739,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 66934,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 82381,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:20.01990109Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 62204,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 82200,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:24.044892918Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 66416,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 73007,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:25.718117562Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 77255,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 128733,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:53:51.690047221Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 37.83473,
+      "WorldPos": {
+        "X": -250.04205,
+        "Y": 8.087604,
+        "Z": 30.118235
+      },
+      "RelPos": {
+        "X": -0.7859706,
+        "Y": 0.03938737,
+        "Z": 2.2981796
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:02.559200888Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58389,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 127556,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:04.476701276Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60920,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 131798,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:07.405966566Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60181,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 135045,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:10.513981825Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 60037,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 133117,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:15.798733457Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 67184,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 144582,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:21.700708827Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61689,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 150259,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:28.172474502Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62476,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 135039,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:29.568954199Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 79092,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 148614,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:54:39.885515341Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 75827,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 187119,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:00.704418706Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58131,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 188970,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:03.811625266Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59844,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 195081,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:09.84144072Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59307,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 200297,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:16.705591469Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 8.983585,
+      "WorldPos": {
+        "X": 1.5827987,
+        "Y": 3.935679,
+        "Z": -22.583578
+      },
+      "RelPos": {
+        "X": 0.75313985,
+        "Y": -0.3379301,
+        "Z": 2.33375
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:18.49448178Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 62633,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 191975,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:20.271468404Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 72865,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 206271,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:22.843310035Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61146,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 212740,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:30.237607704Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62051,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 214133,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:37.319027443Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 67756,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 245250,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:55:59.276799104Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58589,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 224444,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:00.146032638Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 80255,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 248311,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:03.795576072Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59948,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 254387,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:09.610241591Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59769,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 262947,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:11.818055088Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 44.64223,
+      "WorldPos": {
+        "X": -102.78479,
+        "Y": 6.3716707,
+        "Z": 317.2829
+      },
+      "RelPos": {
+        "X": -0.77143013,
+        "Y": 0.031209026,
+        "Z": 2.107809
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:19.206319049Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 60752,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 264840,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:20.157392727Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 59887,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 267415,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:22.817846456Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 59975,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 274791,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:32.289218351Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62067,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 281889,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:56:43.5650946Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 66227,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 304689,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:03.819749225Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63704,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 308257,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:04.128424293Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60330,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 303837,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:05.378400446Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 66108,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 314155,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:09.664985948Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 60052,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 323691,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:20.067192169Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 60865,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 324730,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:20.525883889Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60351,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 327389,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:22.71269897Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 59889,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 336853,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:31.989244145Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 15,
+      "OtherCarID": 16,
+      "ImpactSpeed": 23.996357,
+      "WorldPos": {
+        "X": -98.60322,
+        "Y": 5.5790386,
+        "Z": 373.3994
+      },
+      "RelPos": {
+        "X": -0.7881047,
+        "Y": -0.11047131,
+        "Z": -1.2807758
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:35.071227011Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62783,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 348115,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:36.987730357Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 15,
+      "ImpactSpeed": 22.088165,
+      "WorldPos": {
+        "X": -106.250145,
+        "Y": 6.444098,
+        "Z": 310.7157
+      },
+      "RelPos": {
+        "X": 0.8397838,
+        "Y": 0.04364412,
+        "Z": -1.1753184
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:57:53.89618219Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 70333,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 368587,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:04.073006584Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 59993,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 369942,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:04.690772841Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59309,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 374206,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:09.097583008Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59450,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 368391,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:17.498999987Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 73663,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 387278,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:26.479251856Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 63773,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 384543,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:41.174938249Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 81109,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 385080,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:41.263400336Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 80739,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 399638,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:58:42.957168792Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 67871,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 418447,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:00.207601805Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 66335,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 429250,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:03.695462702Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58989,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 428580,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:04.161056153Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 60078,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 433655,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:08.511933584Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59412,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 442069,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:20.27931446Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 62789,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 451048,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:27.812218621Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 61338,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 467507,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:28.26323115Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 11.4801035,
+      "WorldPos": {
+        "X": -221.82883,
+        "Y": 6.7115088,
+        "Z": 18.638765
+      },
+      "RelPos": {
+        "X": -0.7531461,
+        "Y": -0.25777435,
+        "Z": 2.4668899
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:45.577011506Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 62625,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 465663,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:46.273549864Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 65120,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 465818,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T21:59:48.316657765Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 67067,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 488238,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:02.719701578Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 59026,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 493064,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:07.962282837Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 59463,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 488659,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:08.652992347Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 64493,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 484781,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:22.637743866Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 82415,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 504834,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:23.762591644Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63488,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 512384,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:27.872816655Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 60043,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 532879,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:32.148443975Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 52.47059,
+      "WorldPos": {
+        "X": -249.9529,
+        "Y": 8.051628,
+        "Z": 30.170914
+      },
+      "RelPos": {
+        "X": 0.80535245,
+        "Y": 0.048095927,
+        "Z": 2.2271874
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:34.467317628Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 32.512924,
+      "WorldPos": {
+        "X": 607.6385,
+        "Y": 1.8698356,
+        "Z": 57.80841
+      },
+      "RelPos": {
+        "X": -0.777323,
+        "Y": -0.04566363,
+        "Z": -1.3826513
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:39.46235017Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 19,
+      "ImpactSpeed": 30.403107,
+      "WorldPos": {
+        "X": 607.95355,
+        "Y": 1.8318199,
+        "Z": 61.93704
+      },
+      "RelPos": {
+        "X": -0.7644508,
+        "Y": 0.2783232,
+        "Z": 1.8490088
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:46.770805439Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 19.93299,
+      "WorldPos": {
+        "X": -246.27867,
+        "Y": 7.675321,
+        "Z": 46.942017
+      },
+      "RelPos": {
+        "X": -1.0029705,
+        "Y": 0.114706226,
+        "Z": -1.8480825
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:48.770518051Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 60446,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 530132,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:53.463881216Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 67842,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 530766,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:00:56.460425026Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 70184,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 547258,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:01.661144608Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 7,
+      "LapTime": 58960,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 552527,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:02.103290804Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 29.964302,
+      "WorldPos": {
+        "X": -33.53648,
+        "Y": 2.3873506,
+        "Z": 30.821192
+      },
+      "RelPos": {
+        "X": 0.51375085,
+        "Y": 0.039426386,
+        "Z": 2.262146
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:07.155829268Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 47.52934,
+      "WorldPos": {
+        "X": 554.79584,
+        "Y": -9.634177,
+        "Z": 213.61081
+      },
+      "RelPos": {
+        "X": -0.40499622,
+        "Y": -0.3401801,
+        "Z": 2.4653006
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:12.052973322Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 15,
+      "ImpactSpeed": 25.797651,
+      "WorldPos": {
+        "X": -256.84503,
+        "Y": 8.401481,
+        "Z": 26.218225
+      },
+      "RelPos": {
+        "X": 0.7771783,
+        "Y": -0.045663007,
+        "Z": -1.382657
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:16.869640945Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 3.7860413,
+      "WorldPos": {
+        "X": -118.90106,
+        "Y": 8.079986,
+        "Z": 432.57657
+      },
+      "RelPos": {
+        "X": 0.8929633,
+        "Y": 0.1919197,
+        "Z": 1.7670436
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:17.032665561Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 15,
+      "ImpactSpeed": 19.565325,
+      "WorldPos": {
+        "X": -241.82867,
+        "Y": 7.649433,
+        "Z": 26.85688
+      },
+      "RelPos": {
+        "X": 0.5545147,
+        "Y": -0.00420139,
+        "Z": 2.2253757
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:17.219218873Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 69263,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 553149,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:18.099374392Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 14,
+      "LapTime": 69464,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 567193,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:21.873106228Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 5.8333716,
+      "WorldPos": {
+        "X": -120.49291,
+        "Y": 8.195454,
+        "Z": 433.0098
+      },
+      "RelPos": {
+        "X": 0.8926878,
+        "Y": 0.19192792,
+        "Z": 1.7669395
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:23.949881273Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 2,
+      "LapTime": 61324,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 568327,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:27.29798827Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63516,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 572426,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.785676927Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 14,
+      "ImpactSpeed": 208.04527,
+      "WorldPos": {
+        "X": -125.08344,
+        "Y": 7.97045,
+        "Z": 422.88522
+      },
+      "RelPos": {
+        "X": 0.5726485,
+        "Y": -0.17318496,
+        "Z": 2.3892708
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.78988064Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 109.596054,
+      "WorldPos": {
+        "X": -155.75008,
+        "Y": 10.691232,
+        "Z": 428.7087
+      },
+      "RelPos": {
+        "X": -0.48311728,
+        "Y": 0.079864554,
+        "Z": -2.0332959
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.802121132Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 2,
+      "ImpactSpeed": 57.33579,
+      "WorldPos": {
+        "X": -155.83632,
+        "Y": 10.9676485,
+        "Z": 437.2277
+      },
+      "RelPos": {
+        "X": 1.0044783,
+        "Y": 0.2864175,
+        "Z": -0.66210705
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.880007679Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 14,
+      "ImpactSpeed": 33.481716,
+      "WorldPos": {
+        "X": -153.3954,
+        "Y": 10.366754,
+        "Z": 436.4096
+      },
+      "RelPos": {
+        "X": 0.8063765,
+        "Y": -0.12922801,
+        "Z": 1.9518377
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.89242632Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 29.874668,
+      "WorldPos": {
+        "X": -157.91148,
+        "Y": 11.191903,
+        "Z": 433.64728
+      },
+      "RelPos": {
+        "X": -0.47544488,
+        "Y": 0.43887338,
+        "Z": -2.0616958
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:36.902091511Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 2,
+      "ImpactSpeed": 20.628216,
+      "WorldPos": {
+        "X": -155.02846,
+        "Y": 10.634883,
+        "Z": 437.40915
+      },
+      "RelPos": {
+        "X": -0.75858414,
+        "Y": -0.0334175,
+        "Z": 2.0977073
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:37.867354785Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 7,
+      "ImpactSpeed": 22.242691,
+      "WorldPos": {
+        "X": -153.26666,
+        "Y": 10.334529,
+        "Z": 436.27655
+      },
+      "RelPos": {
+        "X": -0.4491886,
+        "Y": -0.03031699,
+        "Z": 2.2949402
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:37.879778393Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 0,
+      "ImpactSpeed": 212.07497,
+      "WorldPos": {
+        "X": -125.39172,
+        "Y": 7.9315853,
+        "Z": 422.70438
+      },
+      "RelPos": {
+        "X": -0.79995793,
+        "Y": -0.18203239,
+        "Z": -1.1682969
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:38.293510081Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 20.820036,
+      "WorldPos": {
+        "X": -154.84471,
+        "Y": 10.345164,
+        "Z": 441.95435
+      },
+      "RelPos": {
+        "X": 0.40502143,
+        "Y": -0.26062307,
+        "Z": 2.5984004
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:38.309578101Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 0,
+      "ImpactSpeed": 55.3255,
+      "WorldPos": {
+        "X": -155.88245,
+        "Y": 10.784434,
+        "Z": 437.27927
+      },
+      "RelPos": {
+        "X": -0.8507536,
+        "Y": 0.117051594,
+        "Z": -1.7332517
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:38.321211841Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 7,
+      "ImpactSpeed": 17.353468,
+      "WorldPos": {
+        "X": -154.8284,
+        "Y": 10.614723,
+        "Z": 437.38107
+      },
+      "RelPos": {
+        "X": 0.27431127,
+        "Y": 0.009841822,
+        "Z": -1.8450598
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:39.005806337Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 8,
+      "LapTime": 71141,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 597973,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.780944826Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 2,
+      "ImpactSpeed": 3.9263742,
+      "WorldPos": {
+        "X": -156.04315,
+        "Y": 10.846758,
+        "Z": 438.73694
+      },
+      "RelPos": {
+        "X": 0.98290235,
+        "Y": 0.11470618,
+        "Z": -1.8480711
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.790047416Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 7,
+      "ImpactSpeed": 13.8442955,
+      "WorldPos": {
+        "X": -155.96997,
+        "Y": 10.781507,
+        "Z": 436.20627
+      },
+      "RelPos": {
+        "X": 0.4831252,
+        "Y": 0.079863995,
+        "Z": -2.0332792
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.880294582Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 14,
+      "ImpactSpeed": 0.012167076,
+      "WorldPos": {
+        "X": -152.37148,
+        "Y": 10.4214735,
+        "Z": 436.88293
+      },
+      "RelPos": {
+        "X": -0.14010495,
+        "Y": 0.026450079,
+        "Z": 2.2931013
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:41.889876058Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 0,
+      "ImpactSpeed": 12.510661,
+      "WorldPos": {
+        "X": -155.9379,
+        "Y": 10.788488,
+        "Z": 436.2193
+      },
+      "RelPos": {
+        "X": -0.9439887,
+        "Y": 0.120106846,
+        "Z": -0.83350706
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:42.852132175Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 14,
+      "OtherCarID": 7,
+      "ImpactSpeed": 4.888293,
+      "WorldPos": {
+        "X": -152.21939,
+        "Y": 10.089093,
+        "Z": 436.4476
+      },
+      "RelPos": {
+        "X": -0.8429633,
+        "Y": -0.25584397,
+        "Z": 0.76378095
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:43.293749418Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 0,
+      "ImpactSpeed": 6.6065187,
+      "WorldPos": {
+        "X": -155.85612,
+        "Y": 10.839186,
+        "Z": 437.39645
+      },
+      "RelPos": {
+        "X": -0.85524315,
+        "Y": 0.10990144,
+        "Z": -1.8228945
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.780603703Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 7.0252166,
+      "WorldPos": {
+        "X": -154.43533,
+        "Y": 10.270536,
+        "Z": 426.14966
+      },
+      "RelPos": {
+        "X": -1.0029786,
+        "Y": -0.2807202,
+        "Z": -1.7505336
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.789048977Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 7,
+      "ImpactSpeed": 4.07245,
+      "WorldPos": {
+        "X": -154.73566,
+        "Y": 10.885412,
+        "Z": 433.07996
+      },
+      "RelPos": {
+        "X": 1.0476648,
+        "Y": 0.35515678,
+        "Z": 0.65042937
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.88063293Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 0,
+      "ImpactSpeed": 10.610559,
+      "WorldPos": {
+        "X": -154.95769,
+        "Y": 10.717422,
+        "Z": 433.83246
+      },
+      "RelPos": {
+        "X": -0.9346254,
+        "Y": 0.15596303,
+        "Z": -1.2384216
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.893809153Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 8,
+      "ImpactSpeed": 152.5637,
+      "WorldPos": {
+        "X": -152.4925,
+        "Y": 10.206379,
+        "Z": 436.09396
+      },
+      "RelPos": {
+        "X": 0.87033576,
+        "Y": -0.18769015,
+        "Z": 1.6011555
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.904431936Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 2,
+      "ImpactSpeed": 65.09792,
+      "WorldPos": {
+        "X": -157.17609,
+        "Y": 11.171963,
+        "Z": 437.84497
+      },
+      "RelPos": {
+        "X": -0.42879808,
+        "Y": 0.29894054,
+        "Z": -1.7982403
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:46.917077308Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 66.07118,
+      "WorldPos": {
+        "X": -159.44006,
+        "Y": 10.497653,
+        "Z": 436.9085
+      },
+      "RelPos": {
+        "X": 0.89857495,
+        "Y": -0.22570662,
+        "Z": -1.373745
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.129751178Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 1,
+      "ImpactSpeed": 177.34915,
+      "WorldPos": {
+        "X": -136.95294,
+        "Y": 9.23824,
+        "Z": 433.24948
+      },
+      "RelPos": {
+        "X": 0.51375073,
+        "Y": 0.039425522,
+        "Z": 2.262154
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.146057375Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 7,
+      "ImpactSpeed": 121.54132,
+      "WorldPos": {
+        "X": -153.20627,
+        "Y": 10.558446,
+        "Z": 436.44324
+      },
+      "RelPos": {
+        "X": -0.76110685,
+        "Y": -0.020680673,
+        "Z": 2.099689
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.154922584Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 2,
+      "ImpactSpeed": 32.721474,
+      "WorldPos": {
+        "X": -154.8453,
+        "Y": 10.784038,
+        "Z": 437.71323
+      },
+      "RelPos": {
+        "X": -0.6782271,
+        "Y": 0.056191966,
+        "Z": 2.0357244
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.169529194Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 92.664604,
+      "WorldPos": {
+        "X": -158.38455,
+        "Y": 11.312611,
+        "Z": 434.4338
+      },
+      "RelPos": {
+        "X": 0.47544444,
+        "Y": 0.43887326,
+        "Z": -2.0617042
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.177888148Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 8,
+      "ImpactSpeed": 196.0419,
+      "WorldPos": {
+        "X": -137.17503,
+        "Y": 8.95841,
+        "Z": 433.2197
+      },
+      "RelPos": {
+        "X": -0.7918957,
+        "Y": -0.28072026,
+        "Z": -1.7505438
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:47.191592799Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 22.139364,
+      "WorldPos": {
+        "X": -140.57243,
+        "Y": 9.613563,
+        "Z": 438.40848
+      },
+      "RelPos": {
+        "X": 0.78596735,
+        "Y": 0.03938595,
+        "Z": 2.29819
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:48.29426582Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 7,
+      "ImpactSpeed": 23.275885,
+      "WorldPos": {
+        "X": -156.07387,
+        "Y": 11.1435795,
+        "Z": 437.5752
+      },
+      "RelPos": {
+        "X": 0.89219034,
+        "Y": -0.09828663,
+        "Z": -1.7184621
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:48.305346058Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 2,
+      "OtherCarID": 8,
+      "ImpactSpeed": 120.560486,
+      "WorldPos": {
+        "X": -154.25186,
+        "Y": 10.808504,
+        "Z": 437.4832
+      },
+      "RelPos": {
+        "X": 0.7558801,
+        "Y": 0.21606196,
+        "Z": -1.7522763
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:48.311324828Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 2,
+      "ImpactSpeed": 14.722476,
+      "WorldPos": {
+        "X": -154.972,
+        "Y": 10.327267,
+        "Z": 441.98355
+      },
+      "RelPos": {
+        "X": 5.066395e-7,
+        "Y": -0.26021084,
+        "Z": 2.635321
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:51.783451069Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 1,
+      "ImpactSpeed": 25.608603,
+      "WorldPos": {
+        "X": -146.17607,
+        "Y": 9.652548,
+        "Z": 433.87454
+      },
+      "RelPos": {
+        "X": 0.7500482,
+        "Y": -0.29149005,
+        "Z": 2.322259
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:51.88052647Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 7,
+      "OtherCarID": 8,
+      "ImpactSpeed": 9.089698,
+      "WorldPos": {
+        "X": -158.09119,
+        "Y": 11.318608,
+        "Z": 438.1805
+      },
+      "RelPos": {
+        "X": -0.37662733,
+        "Y": -0.26381376,
+        "Z": -1.243058
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:51.888313607Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 7,
+      "ImpactSpeed": 1.5732777,
+      "WorldPos": {
+        "X": -159.71603,
+        "Y": 10.633289,
+        "Z": 437.5311
+      },
+      "RelPos": {
+        "X": 0.96550643,
+        "Y": -0.26382113,
+        "Z": -1.2430785
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.112931089Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 7,
+      "ImpactSpeed": 2.0968513,
+      "WorldPos": {
+        "X": -157.75905,
+        "Y": 11.261579,
+        "Z": 437.76495
+      },
+      "RelPos": {
+        "X": 0.4891746,
+        "Y": 0.43232647,
+        "Z": -2.024809
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.120591818Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 3.4712164,
+      "WorldPos": {
+        "X": -144.16994,
+        "Y": 10.033469,
+        "Z": 439.29456
+      },
+      "RelPos": {
+        "X": -0.8929589,
+        "Y": 0.19192089,
+        "Z": 1.7670469
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.139506263Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 1,
+      "ImpactSpeed": 9.827558,
+      "WorldPos": {
+        "X": -144.2318,
+        "Y": 9.498784,
+        "Z": 437.49704
+      },
+      "RelPos": {
+        "X": 0.87976086,
+        "Y": -0.2966022,
+        "Z": 1.5720578
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.167020804Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 0,
+      "ImpactSpeed": 25.620605,
+      "WorldPos": {
+        "X": -145.73595,
+        "Y": 10.280885,
+        "Z": 434.49033
+      },
+      "RelPos": {
+        "X": -0.9303588,
+        "Y": 0.3876351,
+        "Z": -1.0479064
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:52.178323368Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 8,
+      "ImpactSpeed": 11.638,
+      "WorldPos": {
+        "X": -144.22736,
+        "Y": 9.488884,
+        "Z": 437.4958
+      },
+      "RelPos": {
+        "X": -0.7483559,
+        "Y": -0.33104643,
+        "Z": 2.3312452
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:55.229034507Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 19,
+      "LapTime": 61825,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 659795,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 593333,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:55.853232714Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 15,
+      "LapTime": 67097,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 659795,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 660425,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 16,
+          "LapTime": 600948,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.047530547Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 16,
+      "LapTime": 60591,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 7,
+          "LapTime": 606222,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 621787,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 14,
+          "LapTime": 622607,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 8,
+          "LapTime": 643564,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 19,
+          "LapTime": 659795,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 15,
+          "LapTime": 660425,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 16,
+          "LapTime": 661541,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 2,
+          "LapTime": 628518,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 0,
+          "LapTime": 631842,
+          "Laps": 9,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.114959869Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 8,
+      "ImpactSpeed": 8.485209,
+      "WorldPos": {
+        "X": -140.0359,
+        "Y": 9.269851,
+        "Z": 438.2437
+      },
+      "RelPos": {
+        "X": -0.96426576,
+        "Y": -0.26377523,
+        "Z": -1.2430801
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.13331519Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 8,
+      "OtherCarID": 1,
+      "ImpactSpeed": 0.49061668,
+      "WorldPos": {
+        "X": -143.84271,
+        "Y": 9.422574,
+        "Z": 437.4544
+      },
+      "RelPos": {
+        "X": 0.8671616,
+        "Y": -0.26368892,
+        "Z": 1.4969919
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:01:57.164013996Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 8,
+      "ImpactSpeed": 0.2254504,
+      "WorldPos": {
+        "X": -144.09935,
+        "Y": 9.4405985,
+        "Z": 437.45807
+      },
+      "RelPos": {
+        "X": -0.6401783,
+        "Y": -0.33818176,
+        "Z": 2.3590064
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:04.608024521Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 2,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:10.23118229Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 7,
+      "Message": "1 more race"
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:17.651408203Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "niceone for waiting mate "
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:24.382836813Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 8,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:29.492673616Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 15,
+      "Message": "i drove worst evere blol"
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:29.930449375Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 14,
+      "DriverName": "Spaceman9795",
+      "DriverGUID": "76561198045844392",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:32.039880526Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 15,
+      "DriverName": "rich p",
+      "DriverGUID": "76561198437072463",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:35.81577258Z",
+    "EventType": 57,
+    "Data": {
+      "CarID": 0,
+      "Message": "yes"
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:44.811565046Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:46.862425475Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 7,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:02:57.100805796Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:03:05.264781186Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 16,
+      "DriverName": "Cheezypoof",
+      "DriverGUID": "76561198365646634",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:03:13.336719501Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 19,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:03:13.354320226Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_22_3_RACE.json"
+  }
+]

--- a/fixtures/open-championship/suzuka_east.json
+++ b/fixtures/open-championship/suzuka_east.json
@@ -1,0 +1,14845 @@
+[
+  {
+    "Received": "2019-03-02T22:03:13.357803307Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "ks_red_bull_ring",
+      "TrackConfig": "layout_national",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 37,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530190800",
+      "ElapsedMilliseconds": 1,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:03.488127912Z",
+    "EventType": 56,
+    "Data": 4
+  },
+  {
+    "Received": "2019-03-02T22:04:03.508500787Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 26,
+      "RoadTemp": 38,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:04.747857103Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 0,
+      "CurrentSessionIndex": 0,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Qualify",
+      "Type": 2,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 0,
+      "AmbientTemp": 25,
+      "RoadTemp": 35,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": 0,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:16.748916185Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 18,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:17.053159393Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:20.136255583Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:26.155157637Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:32.431648749Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 10,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:33.649983954Z",
+    "EventType": 51,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 51
+    }
+  },
+  {
+    "Received": "2019-03-02T22:04:33.772023408Z",
+    "EventType": 58,
+    "Data": 18
+  },
+  {
+    "Received": "2019-03-02T22:04:41.321668359Z",
+    "EventType": 58,
+    "Data": 0
+  },
+  {
+    "Received": "2019-03-02T22:04:44.354267187Z",
+    "EventType": 58,
+    "Data": 1
+  },
+  {
+    "Received": "2019-03-02T22:04:44.464251556Z",
+    "EventType": 58,
+    "Data": 10
+  },
+  {
+    "Received": "2019-03-02T22:04:45.49657591Z",
+    "EventType": 58,
+    "Data": 9
+  },
+  {
+    "Received": "2019-03-02T22:05:02.110305847Z",
+    "EventType": 58,
+    "Data": 5
+  },
+  {
+    "Received": "2019-03-02T22:06:05.57626289Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 81230,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:06.426895447Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 85146,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:10.121870891Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 85668,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:21.042946032Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 95577,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:41.471048637Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 99370,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:06:43.609792098Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 129830,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:07.320432731Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60893,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:10.483295297Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64906,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 85668,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:12.182793575Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 62073,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 95577,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:19.243552628Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58216,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129830,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:39.466227737Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 10.208012,
+      "WorldPos": {
+        "X": 880.6847,
+        "Y": -38.984524,
+        "Z": 548.5211
+      },
+      "RelPos": {
+        "X": 0.770637,
+        "Y": 0.03156123,
+        "Z": 2.1065946
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:47.04530853Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 63466,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:56.076898832Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 74620,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:07:59.369985824Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 42.370678,
+      "WorldPos": {
+        "X": 432.46927,
+        "Y": -17.26613,
+        "Z": 81.658394
+      },
+      "RelPos": {
+        "X": 1.0376282,
+        "Y": 0.25316912,
+        "Z": -1.0038949
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:04.37567441Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 2.3292015,
+      "WorldPos": {
+        "X": 431.48233,
+        "Y": -17.673098,
+        "Z": 85.09106
+      },
+      "RelPos": {
+        "X": 0.7518393,
+        "Y": -0.25798073,
+        "Z": 2.4633703
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.374642439Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 1.7273932,
+      "WorldPos": {
+        "X": 431.46,
+        "Y": -16.891727,
+        "Z": 85.17174
+      },
+      "RelPos": {
+        "X": 0.82837784,
+        "Y": -0.021093488,
+        "Z": 2.24126
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.391510025Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 30.361473,
+      "WorldPos": {
+        "X": 429.9293,
+        "Y": -17.499622,
+        "Z": 84.47097
+      },
+      "RelPos": {
+        "X": -0.6262179,
+        "Y": -0.3164721,
+        "Z": 1.241302
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.485865183Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 29.947628,
+      "WorldPos": {
+        "X": 430.91074,
+        "Y": -18.035736,
+        "Z": 87.15836
+      },
+      "RelPos": {
+        "X": -0.8619413,
+        "Y": -0.29390463,
+        "Z": 1.7960964
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:09.504841656Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 46.672718,
+      "WorldPos": {
+        "X": 430.31238,
+        "Y": -17.078253,
+        "Z": 85.66811
+      },
+      "RelPos": {
+        "X": -0.30221856,
+        "Y": 0.66334796,
+        "Z": 0.5874342
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.009471953Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 66684,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.373645175Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 13.129903,
+      "WorldPos": {
+        "X": 430.33582,
+        "Y": -17.117569,
+        "Z": 85.67888
+      },
+      "RelPos": {
+        "X": -0.3648863,
+        "Y": -0.25902927,
+        "Z": 2.553715
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.389020923Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 4.1745076,
+      "WorldPos": {
+        "X": 431.53217,
+        "Y": -17.21572,
+        "Z": 84.830414
+      },
+      "RelPos": {
+        "X": 0.93745446,
+        "Y": -0.29018098,
+        "Z": 1.8765396
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:14.473869733Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 18.47808,
+      "WorldPos": {
+        "X": 430.94147,
+        "Y": -17.263313,
+        "Z": 81.97111
+      },
+      "RelPos": {
+        "X": -0.8671918,
+        "Y": -0.29545838,
+        "Z": 1.7993759
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:18.456496624Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 59199,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:29.385402767Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 24.841875,
+      "WorldPos": {
+        "X": 329.60495,
+        "Y": -1.9889579,
+        "Z": -118.05477
+      },
+      "RelPos": {
+        "X": 0.40502715,
+        "Y": -0.26062295,
+        "Z": 2.5984235
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:42.136388459Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 89928,
+      "Cuts": 4,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:44.483920795Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 128.27638,
+      "WorldPos": {
+        "X": 528.2595,
+        "Y": -16.5767,
+        "Z": -76.93758
+      },
+      "RelPos": {
+        "X": -0.94752896,
+        "Y": -0.26441064,
+        "Z": -0.54707783
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:45.194695289Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 94695,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:08:49.452056349Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62385,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:16.353482476Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 62360,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:17.963796502Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 59498,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:26.705168275Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 90577,
+      "Cuts": 2,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:49.334321424Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64156,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 63466,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:09:51.722561547Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62279,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60893,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:16.444920378Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60087,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:16.693263859Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58754,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:20.136683996Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 98023,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:34.891052426Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 68235,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 64156,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:39.510311946Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 30.158163,
+      "WorldPos": {
+        "X": 1015.14514,
+        "Y": -40.457607,
+        "Z": 518.61237
+      },
+      "RelPos": {
+        "X": 0.5137355,
+        "Y": 0.039426297,
+        "Z": 2.2621727
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:50.530008487Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 61206,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:10:54.222258587Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62503,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:17.159805146Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 8.210459,
+      "WorldPos": {
+        "X": 454.6029,
+        "Y": -15.763637,
+        "Z": 240.63354
+      },
+      "RelPos": {
+        "X": -1.0029753,
+        "Y": 0.11470533,
+        "Z": -1.8480852
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:17.903422343Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 61451,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:21.027577895Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 64326,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:34.415723145Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 6.060513,
+      "WorldPos": {
+        "X": 402.2142,
+        "Y": -15.356009,
+        "Z": 171.58939
+      },
+      "RelPos": {
+        "X": 1.0323999,
+        "Y": 0.21087149,
+        "Z": -1.0133661
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:34.511612675Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 6.7570353,
+      "WorldPos": {
+        "X": 399.6484,
+        "Y": -15.566014,
+        "Z": 163.83081
+      },
+      "RelPos": {
+        "X": -0.9039753,
+        "Y": 0.18978673,
+        "Z": 1.5610628
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:39.417370453Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 1,
+      "OtherCarID": 10,
+      "ImpactSpeed": 19.327225,
+      "WorldPos": {
+        "X": 425.1303,
+        "Y": -15.261997,
+        "Z": 28.401909
+      },
+      "RelPos": {
+        "X": 0.9139701,
+        "Y": -0.26706657,
+        "Z": 1.9019012
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:39.512019482Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 1,
+      "ImpactSpeed": 13.065868,
+      "WorldPos": {
+        "X": 425.1153,
+        "Y": -15.232496,
+        "Z": 28.199049
+      },
+      "RelPos": {
+        "X": -0.9070022,
+        "Y": -0.17091325,
+        "Z": 1.1707482
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:51.345135386Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 0,
+      "ImpactSpeed": 9.316111,
+      "WorldPos": {
+        "X": 734.5443,
+        "Y": -27.534115,
+        "Z": 193.0971
+      },
+      "RelPos": {
+        "X": -0.7859765,
+        "Y": 0.039384842,
+        "Z": 2.2981675
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:52.817895262Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 77930,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:11:59.939894233Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 99802,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:01.990623633Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 71460,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:04.406080232Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 70196,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:20.07629095Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 59057,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 68235,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:54.434053141Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 47.079132,
+      "WorldPos": {
+        "X": 439.4286,
+        "Y": -13.3221035,
+        "Z": 14.565399
+      },
+      "RelPos": {
+        "X": -0.782428,
+        "Y": 0.11593743,
+        "Z": 2.416308
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:12:59.094096121Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 66274,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 62073,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:00.887301354Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60958,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 62279,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:06.293604158Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 61864,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:20.353111541Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 78349,
+      "Cuts": 1,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:20.4238353Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 122542,
+      "Cuts": 3,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:23.851093026Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 18,
+      "ImpactSpeed": 35.786575,
+      "WorldPos": {
+        "X": 959.6878,
+        "Y": -42.73399,
+        "Z": 534.8381
+      },
+      "RelPos": {
+        "X": -0.8595867,
+        "Y": -0.23198149,
+        "Z": -0.441666
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:13:34.540791743Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 37.02332,
+      "WorldPos": {
+        "X": 851.09686,
+        "Y": -37.515785,
+        "Z": 514.4321
+      },
+      "RelPos": {
+        "X": 0.77143675,
+        "Y": 0.0312098,
+        "Z": 2.1078157
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:14:06.134220111Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 67033,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 58216,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 60087,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 60958,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 61206,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 61864,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 66274,
+          "Laps": 3,
+          "Completed": 1
+        },
+        {
+          "CarID": 3,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 999999999,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:14:27.199328138Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 31.278883,
+      "WorldPos": {
+        "X": 1013.32855,
+        "Y": -40.79059,
+        "Z": 527.4942
+      },
+      "RelPos": {
+        "X": -0.7531507,
+        "Y": -0.33792892,
+        "Z": 2.3337357
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:15:55.431607026Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_22_15_QUALIFY.json"
+  },
+  {
+    "Received": "2019-03-02T22:15:55.457241841Z",
+    "EventType": 50,
+    "Data": {
+      "Version": 4,
+      "SessionIndex": 1,
+      "CurrentSessionIndex": 1,
+      "SessionCount": 2,
+      "ServerName": "Big Whiskey v2",
+      "Track": "suzuka",
+      "TrackConfig": "suzukaeast",
+      "Name": "Race",
+      "Type": 3,
+      "Time": 10,
+      "Laps": 0,
+      "WaitTime": 60000,
+      "AmbientTemp": 25,
+      "RoadTemp": 35,
+      "WeatherGraphics": "sol_01_CLear_type=15_time=0_mult=15_start=1530183600",
+      "ElapsedMilliseconds": -59999,
+      "EventType": 50
+    }
+  },
+  {
+    "Received": "2019-03-02T22:16:59.576936617Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 9,
+      "ImpactSpeed": 29.274994,
+      "WorldPos": {
+        "X": 731.3208,
+        "Y": -26.340197,
+        "Z": 141.48248
+      },
+      "RelPos": {
+        "X": -0.9493474,
+        "Y": -0.1772775,
+        "Z": -0.50101185
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:00.589067052Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 10,
+      "ImpactSpeed": 35.802395,
+      "WorldPos": {
+        "X": 731.3822,
+        "Y": -26.350153,
+        "Z": 141.50735
+      },
+      "RelPos": {
+        "X": 0.82416636,
+        "Y": -0.18334407,
+        "Z": -1.5189974
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:27.258576555Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 18,
+      "ImpactSpeed": 0.04724604,
+      "WorldPos": {
+        "X": 672.60394,
+        "Y": -32.71208,
+        "Z": 394.6068
+      },
+      "RelPos": {
+        "X": -0.09260625,
+        "Y": -0.22828183,
+        "Z": -1.9417348
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:28.905804508Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 18,
+      "OtherCarID": 5,
+      "ImpactSpeed": 0.9622092,
+      "WorldPos": {
+        "X": 673.09375,
+        "Y": -32.728104,
+        "Z": 394.9637
+      },
+      "RelPos": {
+        "X": -0.0000923574,
+        "Y": -0.07723366,
+        "Z": 2.4312825
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:55.602014036Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 5,
+      "ImpactSpeed": 5.1747684,
+      "WorldPos": {
+        "X": 318.17624,
+        "Y": -1.5074056,
+        "Z": -108.65015
+      },
+      "RelPos": {
+        "X": -0.9231553,
+        "Y": 0.18566407,
+        "Z": 1.1496537
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:56.44940531Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60998,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:57.241034347Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 5,
+      "OtherCarID": 9,
+      "ImpactSpeed": 4.0861115,
+      "WorldPos": {
+        "X": 318.17493,
+        "Y": -1.4920442,
+        "Z": -108.639046
+      },
+      "RelPos": {
+        "X": 1.010175,
+        "Y": 0.18538913,
+        "Z": -0.87796223
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:17:58.141494126Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 62696,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:01.082045314Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 65614,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:01.799592658Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 66348,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:02.514717389Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 67035,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:02.642686722Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 67164,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 60993,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 67178,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:19.519447555Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 1,
+      "ImpactSpeed": 14.583844,
+      "WorldPos": {
+        "X": 959.93976,
+        "Y": -42.45596,
+        "Z": 534.0925
+      },
+      "RelPos": {
+        "X": -0.7780968,
+        "Y": 0.031857852,
+        "Z": 2.4402232
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:18:56.883296572Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60437,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 66348,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 67178,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:02.474971216Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60682,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 67178,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:02.655285274Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 60029,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 65608,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:04.729539889Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 63672,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 62692,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:07.058267955Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 68907,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 67026,
+          "Laps": 1,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:08.775286933Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 66289,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 121428,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:24.606761793Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 10,
+      "OtherCarID": 9,
+      "ImpactSpeed": 29.226295,
+      "WorldPos": {
+        "X": 874.05597,
+        "Y": -38.877777,
+        "Z": 571.55273
+      },
+      "RelPos": {
+        "X": 0.93989664,
+        "Y": 0.018473051,
+        "Z": -1.174458
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:25.61541752Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 10,
+      "ImpactSpeed": 31.032682,
+      "WorldPos": {
+        "X": 874.09625,
+        "Y": -38.89613,
+        "Z": 571.54816
+      },
+      "RelPos": {
+        "X": -0.7586524,
+        "Y": 0.017954648,
+        "Z": 2.0891225
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:29.609639762Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 18.212961,
+      "WorldPos": {
+        "X": 819.7805,
+        "Y": -37.148586,
+        "Z": 561.0042
+      },
+      "RelPos": {
+        "X": -0.7714222,
+        "Y": 0.031207677,
+        "Z": 2.1077607
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:19:56.6830956Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59798,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 127193,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:03.708788297Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 60986,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 129280,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:06.434502749Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 61703,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 133320,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:11.732091608Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 62970,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 127026,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:14.725736981Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 72262,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 131599,
+          "Laps": 2,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:18.451431028Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 71410,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 181223,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:20:56.470308278Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59789,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 188185,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:02.122097759Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58462,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 190981,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:08.640771584Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62202,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 196288,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:15.422556126Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 63688,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 199289,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:15.661170491Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60931,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 203009,
+          "Laps": 3,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:21.080650048Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 62627,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 241010,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:21:56.176570475Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59708,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 246648,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:00.218967316Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58127,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 253182,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:10.74916945Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62095,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 260218,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:16.263176936Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 60594,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 259976,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:19.166035755Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 63726,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 265643,
+          "Laps": 4,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:25.136210669Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 1,
+      "LapTime": 64051,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 300715,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:47.857006695Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 1,
+      "DriverName": "Danny Wilson",
+      "DriverGUID": "76561198023931313",
+      "CarModel": "a3dr_ferrari_512tr",
+      "CarSkin": "Rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:56.923902026Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60757,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 304771,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:22:58.493854929Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58237,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 315279,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:12.62026879Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 61885,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 320811,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:18.332244305Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 62073,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 323706,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:36.187508311Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 77044,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 361471,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:52.308316433Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 5,
+      "ImpactSpeed": 29.461843,
+      "WorldPos": {
+        "X": 972.1922,
+        "Y": -41.874866,
+        "Z": 483.02713
+      },
+      "RelPos": {
+        "X": -0.7531311,
+        "Y": -0.3379306,
+        "Z": 2.3337069
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:56.521575709Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 59608,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 363005,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:23:56.83746289Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 58375,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 382883,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:19.826861955Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 61497,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 377166,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:26.128980689Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 73500,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 400744,
+          "Laps": 6,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:48.233469058Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 72023,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 9,
+          "LapTime": 421381,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:58.000113936Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 61161,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 421076,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:24:58.305760797Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 61777,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 444380,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:15.686784972Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 9,
+      "OtherCarID": 0,
+      "ImpactSpeed": 15.259357,
+      "WorldPos": {
+        "X": 963.2201,
+        "Y": -41.728924,
+        "Z": 562.36316
+      },
+      "RelPos": {
+        "X": -0.96013355,
+        "Y": 0.11289532,
+        "Z": -0.6887216
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:16.509186943Z",
+    "EventType": 10,
+    "Data": {
+      "CarID": 0,
+      "OtherCarID": 9,
+      "ImpactSpeed": 10.878339,
+      "WorldPos": {
+        "X": 963.06335,
+        "Y": -41.66753,
+        "Z": 562.5592
+      },
+      "RelPos": {
+        "X": 0.9960668,
+        "Y": 0.25453144,
+        "Z": 1.3268081
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:21.274078643Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 61452,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 450670,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:28.302803301Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62181,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 472764,
+          "Laps": 7,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:25:54.817024017Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 66594,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 482541,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:00.851566174Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 62851,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 482853,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:01.638571645Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 63338,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 505830,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:22.901867163Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 61627,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 512849,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:26:38.945184846Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 70640,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 539356,
+          "Laps": 8,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:00.513296546Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 65704,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 0,
+          "LapTime": 546187,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:01.666366355Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 0,
+      "LapTime": 60005,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 545392,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:10.349987713Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 9,
+      "LapTime": 69485,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 567456,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:25.708871079Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 9,
+      "ImpactSpeed": 90.43727,
+      "WorldPos": {
+        "X": 1015.6104,
+        "Y": -40.448257,
+        "Z": 516.2672
+      },
+      "RelPos": {
+        "X": 0.7714079,
+        "Y": 0.031207928,
+        "Z": 2.1077886
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:29.569359312Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 10,
+      "LapTime": 66664,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 634118,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 18,
+          "LapTime": 583486,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:30.702371409Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 9,
+      "ImpactSpeed": 6.7225127,
+      "WorldPos": {
+        "X": 1011.8523,
+        "Y": -40.470596,
+        "Z": 534.69403
+      },
+      "RelPos": {
+        "X": 0.7714232,
+        "Y": 0.03120906,
+        "Z": 2.1077783
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:41.403189367Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 18,
+      "LapTime": 62440,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 634118,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 18,
+          "LapTime": 645925,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 605059,
+          "Laps": 9,
+          "Completed": 0
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:27:44.721340534Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 129.45352,
+      "WorldPos": {
+        "X": 1022.6137,
+        "Y": -40.4104,
+        "Z": 485.11365
+      },
+      "RelPos": {
+        "X": -0.6565897,
+        "Y": -0.23697315,
+        "Z": 2.0269265
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:09.400933569Z",
+    "EventType": 73,
+    "Data": {
+      "CarID": 5,
+      "LapTime": 68901,
+      "Cuts": 0,
+      "CarsCount": 22,
+      "Cars": [
+        {
+          "CarID": 0,
+          "LapTime": 606189,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 9,
+          "LapTime": 614873,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 10,
+          "LapTime": 634118,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 18,
+          "LapTime": 645925,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 5,
+          "LapTime": 673959,
+          "Laps": 10,
+          "Completed": 1
+        },
+        {
+          "CarID": 1,
+          "LapTime": 329685,
+          "Laps": 5,
+          "Completed": 0
+        },
+        {
+          "CarID": 3,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 7,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 8,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 6,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 4,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 11,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 12,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 13,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 14,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 15,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 16,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 17,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 2,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 19,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 20,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        },
+        {
+          "CarID": 21,
+          "LapTime": 0,
+          "Laps": 0,
+          "Completed": 0
+        }
+      ]
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:09.702349046Z",
+    "EventType": 11,
+    "Data": {
+      "CarID": 10,
+      "ImpactSpeed": 57.04306,
+      "WorldPos": {
+        "X": 850.11346,
+        "Y": -37.75909,
+        "Z": 512.9045
+      },
+      "RelPos": {
+        "X": 0.96553004,
+        "Y": -0.26382154,
+        "Z": -1.2430332
+      }
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:16.025631943Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 18,
+      "DriverName": "Callum Jones",
+      "DriverGUID": "76561198020046073",
+      "CarModel": "ks_alfa_33_stradale",
+      "CarSkin": "00_rosso",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:17.071204427Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 10,
+      "DriverName": "L33 CR055L3Y",
+      "DriverGUID": "76561198055388877",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "10_carrera_grey",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:20.412880097Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 5,
+      "DriverName": "Seb",
+      "DriverGUID": "76561198074322763",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Viola_Ophelia",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:36.518062594Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 9,
+      "DriverName": "Joseph Elton",
+      "DriverGUID": "76561198029578060",
+      "CarModel": "ks_porsche_911_carrera_rsr",
+      "CarSkin": "03_kunosracing_17",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:56.403955889Z",
+    "EventType": 52,
+    "Data": {
+      "CarID": 0,
+      "DriverName": "namelesssboy",
+      "DriverGUID": "76561198022717360",
+      "CarModel": "a3dr_lambo_diablo_vt",
+      "CarSkin": "Silver",
+      "EventType": 52
+    }
+  },
+  {
+    "Received": "2019-03-02T22:28:56.427468605Z",
+    "EventType": 55,
+    "Data": "results/2019_3_2_22_28_RACE.json"
+  }
+]

--- a/fixtures/results/2019_3_2_14_41_PRACTICE.json
+++ b/fixtures/results/2019_3_2_14_41_PRACTICE.json
@@ -1,0 +1,358 @@
+{
+	"TrackName": "suzuka",
+	"TrackConfig": "suzukagp",
+	"Type": "PRACTICE",
+	"DurationSecs": 0,
+	"RaceLaps": 0,
+	"Cars": [
+		{
+			"CarId": 0,
+			"Driver": {
+				"Name": "Henry Spencer",
+				"Team": "Wrong Bizniz Racing",
+				"Nation": "",
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "kraken_31",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "Wrong Bizniz Racing",
+				"Nation": "",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "kraken_22",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Name": "Joseph Elton",
+				"Team": "Dude, where's my wang!?",
+				"Nation": "",
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				]
+			},
+			"Model": "ks_mercedes_amg_gt3",
+			"Skin": "dude_wheres_my_wang_33",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 3,
+			"Driver": {
+				"Name": "Warren Pilz",
+				"Team": "Dude, where's my wang!?",
+				"Nation": "",
+				"Guid": "76561198084281699",
+				"GuidsList": [
+					"76561198084281699"
+				]
+			},
+			"Model": "ks_mercedes_amg_gt3",
+			"Skin": "dude_wheres_my_wang_11",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Name": "Jayan Mistry",
+				"Team": "Purple Helmets",
+				"Nation": "",
+				"Guid": "76561198247914110",
+				"GuidsList": [
+					"76561198247914110"
+				]
+			},
+			"Model": "ks_lamborghini_huracan_gt3",
+			"Skin": "Racing_Jayan",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Name": "Bradley Ward",
+				"Team": "Purple Helmets",
+				"Nation": "",
+				"Guid": "76561198256908075",
+				"GuidsList": [
+					"76561198256908075"
+				]
+			},
+			"Model": "ks_lamborghini_huracan_gt3",
+			"Skin": "Racing_Brad",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 6,
+			"Driver": {
+				"Name": "Danny Wilson",
+				"Team": "Catch My Drift",
+				"Nation": "",
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				]
+			},
+			"Model": "ks_nissan_gtr_gt3",
+			"Skin": "CatchMyDriftWanny",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"Model": "ks_nissan_gtr_gt3",
+			"Skin": "CatchMyDriftLee",
+			"BallastKG": 0,
+			"Restrictor": 0
+		}
+	],
+	"Result": [
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"BestLap": 129630,
+			"TotalTime": 7274534,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Henry Spencer",
+			"DriverGuid": "76561198022717360",
+			"CarId": 0,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 2,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Warren Pilz",
+			"DriverGuid": "76561198084281699",
+			"CarId": 3,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Jayan Mistry",
+			"DriverGuid": "76561198247914110",
+			"CarId": 4,
+			"CarModel": "ks_lamborghini_huracan_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Bradley Ward",
+			"DriverGuid": "76561198256908075",
+			"CarId": 5,
+			"CarModel": "ks_lamborghini_huracan_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 6,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Callum Jones",
+			"DriverGuid": "76561198020046073",
+			"CarId": 1,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		}
+	],
+	"Laps": [
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 64671496,
+			"LapTime": 177458,
+			"Sectors": [
+				102200,
+				58465,
+				16793
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 64806918,
+			"LapTime": 135425,
+			"Sectors": [
+				59893,
+				58338,
+				17194
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 64938016,
+			"LapTime": 131101,
+			"Sectors": [
+				58205,
+				59270,
+				13626
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 65072852,
+			"LapTime": 134839,
+			"Sectors": [
+				59225,
+				61849,
+				13765
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 65206001,
+			"LapTime": 133151,
+			"Sectors": [
+				58317,
+				58882,
+				15952
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 65335629,
+			"LapTime": 129630,
+			"Sectors": [
+				56343,
+				59345,
+				13942
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 65465446,
+			"LapTime": 129820,
+			"Sectors": [
+				56164,
+				59742,
+				13914
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 7,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 65596069,
+			"LapTime": 130623,
+			"Sectors": [
+				57047,
+				59810,
+				13766
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		}
+	],
+	"Events": null
+}

--- a/fixtures/results/2019_3_2_17_27_PRACTICE.json
+++ b/fixtures/results/2019_3_2_17_27_PRACTICE.json
@@ -1,0 +1,1802 @@
+{
+	"TrackName": "suzuka",
+	"TrackConfig": "suzukagp",
+	"Type": "PRACTICE",
+	"DurationSecs": 0,
+	"RaceLaps": 0,
+	"Cars": [
+		{
+			"CarId": 0,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "Wrong Bizniz Racing",
+				"Nation": "",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "kraken_22",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Name": "Bradley Ward",
+				"Team": "Purple Helmets",
+				"Nation": "",
+				"Guid": "76561198256908075",
+				"GuidsList": [
+					"76561198256908075"
+				]
+			},
+			"Model": "ks_lamborghini_huracan_gt3",
+			"Skin": "Racing_Brad",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"Model": "ks_nissan_gtr_gt3",
+			"Skin": "CatchMyDriftLee",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "00_racing_59",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Name": "Danny Wilson",
+				"Team": "",
+				"Nation": "GBR",
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				]
+			},
+			"Model": "ks_nissan_gtr_gt3",
+			"Skin": "CatchMyDriftWanny",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Name": "Henry Spencer",
+				"Team": "Wrong Bizniz Racing",
+				"Nation": "",
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "kraken_31",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 6,
+			"Driver": {
+				"Name": "Joseph Elton",
+				"Team": "",
+				"Nation": "GBR",
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				]
+			},
+			"Model": "ks_mercedes_amg_gt3",
+			"Skin": "dude_wheres_my_wang_33",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Name": "Warren Pilz",
+				"Team": "Dude, where's my wang!?",
+				"Nation": "",
+				"Guid": "76561198084281699",
+				"GuidsList": [
+					"76561198084281699"
+				]
+			},
+			"Model": "ks_mercedes_amg_gt3",
+			"Skin": "dude_wheres_my_wang_11",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Name": "Jayan Mistry",
+				"Team": "Purple Helmets",
+				"Nation": "",
+				"Guid": "76561198247914110",
+				"GuidsList": [
+					"76561198247914110"
+				]
+			},
+			"Model": "ks_lamborghini_huracan_gt3",
+			"Skin": "Racing_Jayan",
+			"BallastKG": 0,
+			"Restrictor": 0
+		}
+	],
+	"Result": [
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"BestLap": 122151,
+			"TotalTime": 6712320,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"BestLap": 124698,
+			"TotalTime": 5599442,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"BestLap": 126325,
+			"TotalTime": 6562856,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 130991,
+			"TotalTime": 5083424,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Callum Jones",
+			"DriverGuid": "76561198020046073",
+			"CarId": 0,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Bradley Ward",
+			"DriverGuid": "76561198256908075",
+			"CarId": 1,
+			"CarModel": "ks_lamborghini_huracan_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Henry Spencer",
+			"DriverGuid": "76561198022717360",
+			"CarId": 5,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Warren Pilz",
+			"DriverGuid": "76561198084281699",
+			"CarId": 7,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Jayan Mistry",
+			"DriverGuid": "76561198247914110",
+			"CarId": 8,
+			"CarModel": "ks_lamborghini_huracan_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		}
+	],
+	"Laps": [
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 208494,
+			"LapTime": 137202,
+			"Sectors": [
+				64815,
+				58572,
+				13815
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 225798,
+			"LapTime": 171617,
+			"Sectors": [
+				90352,
+				66911,
+				14354
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 354094,
+			"LapTime": 145606,
+			"Sectors": [
+				72341,
+				59135,
+				14130
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 377013,
+			"LapTime": 151220,
+			"Sectors": [
+				70297,
+				64179,
+				16744
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 489048,
+			"LapTime": 134956,
+			"Sectors": [
+				57826,
+				62928,
+				14202
+			],
+			"Cuts": 4,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 515752,
+			"LapTime": 138742,
+			"Sectors": [
+				61198,
+				63490,
+				14054
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 616156,
+			"LapTime": 127112,
+			"Sectors": [
+				54915,
+				58679,
+				13518
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 655038,
+			"LapTime": 139289,
+			"Sectors": [
+				61318,
+				63464,
+				14507
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 743346,
+			"LapTime": 127191,
+			"Sectors": [
+				56059,
+				57920,
+				13212
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 793897,
+			"LapTime": 138859,
+			"Sectors": [
+				62138,
+				62969,
+				13752
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 884876,
+			"LapTime": 141533,
+			"Sectors": [
+				61254,
+				63638,
+				16641
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 1092708,
+			"LapTime": 298815,
+			"Sectors": [
+				220659,
+				64926,
+				13230
+			],
+			"Cuts": 6,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 1229119,
+			"LapTime": 136413,
+			"Sectors": [
+				61861,
+				61218,
+				13334
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 1367807,
+			"LapTime": 138690,
+			"Sectors": [
+				62347,
+				61349,
+				14994
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 1504045,
+			"LapTime": 136237,
+			"Sectors": [
+				60543,
+				61091,
+				14603
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 1740399,
+			"LapTime": 236355,
+			"Sectors": [
+				156083,
+				65538,
+				14734
+			],
+			"Cuts": 4,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 1876660,
+			"LapTime": 136268,
+			"Sectors": [
+				61434,
+				60376,
+				14458
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2012568,
+			"LapTime": 135911,
+			"Sectors": [
+				60456,
+				61479,
+				13976
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2146489,
+			"LapTime": 133923,
+			"Sectors": [
+				60226,
+				59728,
+				13969
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2296487,
+			"LapTime": 149994,
+			"Sectors": [
+				75388,
+				59882,
+				14724
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2512210,
+			"LapTime": 147029,
+			"Sectors": [
+				69958,
+				62572,
+				14499
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2675692,
+			"LapTime": 163487,
+			"Sectors": [
+				88756,
+				60638,
+				14093
+			],
+			"Cuts": 3,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 2726668,
+			"LapTime": 1841812,
+			"Sectors": [
+				1770473,
+				57600,
+				13739
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2807601,
+			"LapTime": 131911,
+			"Sectors": [
+				58539,
+				59701,
+				13671
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 2943203,
+			"LapTime": 135608,
+			"Sectors": [
+				61750,
+				59891,
+				13967
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 3265272,
+			"LapTime": 322072,
+			"Sectors": [
+				246729,
+				60948,
+				14395
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 3400352,
+			"LapTime": 135082,
+			"Sectors": [
+				59869,
+				60849,
+				14364
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 3535311,
+			"LapTime": 134961,
+			"Sectors": [
+				60126,
+				60731,
+				14104
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 3669166,
+			"LapTime": 133856,
+			"Sectors": [
+				60182,
+				59918,
+				13756
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 3800868,
+			"LapTime": 131704,
+			"Sectors": [
+				59096,
+				59022,
+				13586
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 3945655,
+			"LapTime": 144775,
+			"Sectors": [
+				72145,
+				58919,
+				13711
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4092766,
+			"LapTime": 147128,
+			"Sectors": [
+				73715,
+				58888,
+				14525
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4247041,
+			"LapTime": 154280,
+			"Sectors": [
+				80409,
+				60309,
+				13562
+			],
+			"Cuts": 3,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4384122,
+			"LapTime": 137082,
+			"Sectors": [
+				60843,
+				62244,
+				13995
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4537249,
+			"LapTime": 153130,
+			"Sectors": [
+				73480,
+				65718,
+				13932
+			],
+			"Cuts": 4,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 4626500,
+			"LapTime": 155787,
+			"Sectors": [
+				82013,
+				59742,
+				14032
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4685384,
+			"LapTime": 148137,
+			"Sectors": [
+				73617,
+				60538,
+				13982
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 4794987,
+			"LapTime": 141733,
+			"Sectors": [
+				67861,
+				59454,
+				14418
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4820264,
+			"LapTime": 134882,
+			"Sectors": [
+				61123,
+				59157,
+				14602
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 4843215,
+			"LapTime": 216715,
+			"Sectors": [
+				141965,
+				59491,
+				15259
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 4922534,
+			"LapTime": 127549,
+			"Sectors": [
+				56157,
+				57838,
+				13554
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 4953657,
+			"LapTime": 133396,
+			"Sectors": [
+				60015,
+				59778,
+				13603
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 4971433,
+			"LapTime": 128219,
+			"Sectors": [
+				54442,
+				60206,
+				13571
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5048856,
+			"LapTime": 126325,
+			"Sectors": [
+				54896,
+				58095,
+				13334
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 5084645,
+			"LapTime": 130991,
+			"Sectors": [
+				58951,
+				58504,
+				13536
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5096891,
+			"LapTime": 125458,
+			"Sectors": [
+				54462,
+				57766,
+				13230
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5216384,
+			"LapTime": 167531,
+			"Sectors": [
+				92274,
+				60057,
+				15200
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5223465,
+			"LapTime": 126573,
+			"Sectors": [
+				54690,
+				58509,
+				13374
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5350426,
+			"LapTime": 126962,
+			"Sectors": [
+				54656,
+				58393,
+				13913
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5475124,
+			"LapTime": 124698,
+			"Sectors": [
+				54138,
+				57411,
+				13149
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5600661,
+			"LapTime": 125536,
+			"Sectors": [
+				54710,
+				57353,
+				13473
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 5689649,
+			"LapTime": 181963,
+			"Sectors": [
+				112074,
+				56817,
+				13072
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5784865,
+			"LapTime": 568488,
+			"Sectors": [
+				475072,
+				80109,
+				13307
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 5813229,
+			"LapTime": 123584,
+			"Sectors": [
+				54046,
+				56601,
+				12937
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 5916204,
+			"LapTime": 131341,
+			"Sectors": [
+				57446,
+				59054,
+				14841
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 5936896,
+			"LapTime": 123667,
+			"Sectors": [
+				53669,
+				57007,
+				12991
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 6043702,
+			"LapTime": 127500,
+			"Sectors": [
+				55760,
+				58181,
+				13559
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 6060124,
+			"LapTime": 123233,
+			"Sectors": [
+				53830,
+				56556,
+				12847
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 6180912,
+			"LapTime": 137213,
+			"Sectors": [
+				55498,
+				57911,
+				23804
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 6183380,
+			"LapTime": 123258,
+			"Sectors": [
+				53674,
+				56750,
+				12834
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 6306330,
+			"LapTime": 122953,
+			"Sectors": [
+				53442,
+				56362,
+				13149
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 6436191,
+			"LapTime": 255283,
+			"Sectors": [
+				175179,
+				59723,
+				20381
+			],
+			"Cuts": 5,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 6564076,
+			"LapTime": 127887,
+			"Sectors": [
+				55968,
+				58216,
+				13703
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 6591397,
+			"LapTime": 285071,
+			"Sectors": [
+				215853,
+				56493,
+				12725
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 6713547,
+			"LapTime": 122151,
+			"Sectors": [
+				53507,
+				55904,
+				12740
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		}
+	],
+	"Events": [
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 21.86871,
+			"WorldPosition": {
+				"X": 396.49063,
+				"Y": -11.181237,
+				"Z": -10.749383
+			},
+			"RelPosition": {
+				"X": 0.58352405,
+				"Y": -0.28793952,
+				"Z": 2.501509
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 43.29927,
+			"WorldPosition": {
+				"X": 476.57767,
+				"Y": -16.846413,
+				"Z": 240.94739
+			},
+			"RelPosition": {
+				"X": 0.5434457,
+				"Y": -0.28568467,
+				"Z": 2.5242102
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 3.277728,
+			"WorldPosition": {
+				"X": 469.93176,
+				"Y": -16.659958,
+				"Z": 240.81664
+			},
+			"RelPosition": {
+				"X": 0.81069154,
+				"Y": -0.30072471,
+				"Z": 2.3729131
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 48.901802,
+			"WorldPosition": {
+				"X": 849.28906,
+				"Y": -37.844955,
+				"Z": 511.75583
+			},
+			"RelPosition": {
+				"X": -0.54346836,
+				"Y": -0.28568667,
+				"Z": 2.5242488
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 41.600838,
+			"WorldPosition": {
+				"X": 844.1819,
+				"Y": -37.72828,
+				"Z": 504.17322
+			},
+			"RelPosition": {
+				"X": -0.54346025,
+				"Y": -0.2856844,
+				"Z": 2.524219
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 2,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 34.408127,
+			"WorldPosition": {
+				"X": 225.53162,
+				"Y": -1.24474,
+				"Z": -68.36817
+			},
+			"RelPosition": {
+				"X": 0.74748397,
+				"Y": -0.33388427,
+				"Z": 2.1889575
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 42.19784,
+			"WorldPosition": {
+				"X": 616.6647,
+				"Y": -24.565073,
+				"Z": 289.72134
+			},
+			"RelPosition": {
+				"X": -0.5474036,
+				"Y": 0.015814364,
+				"Z": 2.4418187
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 36.13691,
+			"WorldPosition": {
+				"X": 464.23148,
+				"Y": -15.321805,
+				"Z": 240.78505
+			},
+			"RelPosition": {
+				"X": 0.998603,
+				"Y": 0.7532581,
+				"Z": -2.0160532
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 32.870403,
+			"WorldPosition": {
+				"X": 470.6104,
+				"Y": -16.681084,
+				"Z": 240.83888
+			},
+			"RelPosition": {
+				"X": 0.9292245,
+				"Y": -0.30135825,
+				"Z": 2.1678312
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 10.00884,
+			"WorldPosition": {
+				"X": 392.56082,
+				"Y": -9.917922,
+				"Z": -19.185528
+			},
+			"RelPosition": {
+				"X": 0.5434431,
+				"Y": -0.28568408,
+				"Z": 2.5242047
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 53.903976,
+			"WorldPosition": {
+				"X": -205.15396,
+				"Y": -10.46485,
+				"Z": 47.602528
+			},
+			"RelPosition": {
+				"X": 0.54344237,
+				"Y": -0.28568372,
+				"Z": 2.5242236
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 2,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 53.381763,
+			"WorldPosition": {
+				"X": 843.50964,
+				"Y": -37.65036,
+				"Z": 503.19186
+			},
+			"RelPosition": {
+				"X": 0.098501205,
+				"Y": -0.2640856,
+				"Z": 2.213798
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 2,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 65.48285,
+			"WorldPosition": {
+				"X": -258.0584,
+				"Y": 4.1046114,
+				"Z": -246.0863
+			},
+			"RelPosition": {
+				"X": 0.635136,
+				"Y": -0.33556178,
+				"Z": 2.1926355
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 2,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 25.27561,
+			"WorldPosition": {
+				"X": 760.2099,
+				"Y": -35.094692,
+				"Z": 391.44363
+			},
+			"RelPosition": {
+				"X": -0.99502397,
+				"Y": -0.33058512,
+				"Z": 1.9791914
+			}
+		}
+	]
+}

--- a/fixtures/results/2019_3_2_19_30_PRACTICE.json
+++ b/fixtures/results/2019_3_2_19_30_PRACTICE.json
@@ -1,0 +1,796 @@
+{
+	"TrackName": "suzuka",
+	"TrackConfig": "suzukagp",
+	"Type": "PRACTICE",
+	"DurationSecs": 0,
+	"RaceLaps": 0,
+	"Cars": [
+		{
+			"CarId": 0,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "",
+				"Nation": "ABW",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "kraken_22",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Name": "Bradley Ward",
+				"Team": "Purple Helmets",
+				"Nation": "",
+				"Guid": "76561198256908075",
+				"GuidsList": [
+					"76561198256908075"
+				]
+			},
+			"Model": "ks_lamborghini_huracan_gt3",
+			"Skin": "Racing_Brad",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Name": "L33 CR055L3Y",
+				"Team": "",
+				"Nation": "PLA",
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				]
+			},
+			"Model": "ks_nissan_gtr_gt3",
+			"Skin": "CatchMyDriftLee",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "00_racing_59",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Name": "Danny Wilson",
+				"Team": "",
+				"Nation": "GBR",
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				]
+			},
+			"Model": "ks_nissan_gtr_gt3",
+			"Skin": "CatchMyDriftWanny",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Name": "Henry Spencer",
+				"Team": "Wrong Bizniz Racing",
+				"Nation": "",
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				]
+			},
+			"Model": "ks_mclaren_650_gt3",
+			"Skin": "kraken_31",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 6,
+			"Driver": {
+				"Name": "Joseph Elton",
+				"Team": "",
+				"Nation": "GBR",
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				]
+			},
+			"Model": "ks_mercedes_amg_gt3",
+			"Skin": "dude_wheres_my_wang_33",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Name": "Warren Pilz",
+				"Team": "Dude, where's my wang!?",
+				"Nation": "",
+				"Guid": "76561198084281699",
+				"GuidsList": [
+					"76561198084281699"
+				]
+			},
+			"Model": "ks_mercedes_amg_gt3",
+			"Skin": "dude_wheres_my_wang_11",
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Name": "Jayan Mistry",
+				"Team": "Purple Helmets",
+				"Nation": "",
+				"Guid": "76561198247914110",
+				"GuidsList": [
+					"76561198247914110"
+				]
+			},
+			"Model": "ks_lamborghini_huracan_gt3",
+			"Skin": "Racing_Jayan",
+			"BallastKG": 0,
+			"Restrictor": 0
+		}
+	],
+	"Result": [
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"BestLap": 124791,
+			"TotalTime": 4396350,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Callum Jones",
+			"DriverGuid": "76561198020046073",
+			"CarId": 0,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 125978,
+			"TotalTime": 6997981,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 131891,
+			"TotalTime": 1769704,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"BestLap": 196138,
+			"TotalTime": 7240753,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Bradley Ward",
+			"DriverGuid": "76561198256908075",
+			"CarId": 1,
+			"CarModel": "ks_lamborghini_huracan_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "L33 CR055L3Y",
+			"DriverGuid": "76561198055388877",
+			"CarId": 2,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Henry Spencer",
+			"DriverGuid": "76561198022717360",
+			"CarId": 5,
+			"CarModel": "ks_mclaren_650_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Warren Pilz",
+			"DriverGuid": "76561198084281699",
+			"CarId": 7,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Jayan Mistry",
+			"DriverGuid": "76561198247914110",
+			"CarId": 8,
+			"CarModel": "ks_lamborghini_huracan_gt3",
+			"BestLap": 999999999,
+			"TotalTime": 0,
+			"BallastKG": 0,
+			"Restrictor": 0
+		}
+	],
+	"Laps": [
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 8175831,
+			"LapTime": 178143,
+			"Sectors": [
+				104171,
+				60076,
+				13896
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 8309706,
+			"LapTime": 133879,
+			"Sectors": [
+				59408,
+				61106,
+				13365
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 8442968,
+			"LapTime": 133264,
+			"Sectors": [
+				60045,
+				59710,
+				13509
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 8574857,
+			"LapTime": 131891,
+			"Sectors": [
+				59774,
+				58604,
+				13513
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 8729013,
+			"LapTime": 154159,
+			"Sectors": [
+				69564,
+				59921,
+				24674
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 8927549,
+			"LapTime": 198537,
+			"Sectors": [
+				125888,
+				58802,
+				13847
+			],
+			"Cuts": 3,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Seb",
+			"DriverGuid": "76561198074322763",
+			"CarId": 3,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 9060929,
+			"LapTime": 133379,
+			"Sectors": [
+				60583,
+				58747,
+				14049
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 10526816,
+			"LapTime": 3235545,
+			"Sectors": [
+				3161398,
+				60084,
+				14063
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 10651919,
+			"LapTime": 125104,
+			"Sectors": [
+				54620,
+				57043,
+				13441
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 10779788,
+			"LapTime": 127868,
+			"Sectors": [
+				53826,
+				60857,
+				13185
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 10906514,
+			"LapTime": 126727,
+			"Sectors": [
+				54425,
+				58271,
+				14031
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 11303453,
+			"LapTime": 396937,
+			"Sectors": [
+				325774,
+				57353,
+				13810
+			],
+			"Cuts": 2,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 11432712,
+			"LapTime": 129259,
+			"Sectors": [
+				58073,
+				57488,
+				13698
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 11562782,
+			"LapTime": 130069,
+			"Sectors": [
+				57934,
+				57812,
+				14323
+			],
+			"Cuts": 1,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Danny Wilson",
+			"DriverGuid": "76561198023931313",
+			"CarId": 4,
+			"CarModel": "ks_nissan_gtr_gt3",
+			"Timestamp": 11687573,
+			"LapTime": 124791,
+			"Sectors": [
+				53826,
+				57401,
+				13564
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Callum Jones",
+			"DriverGuid": "76561198020046073",
+			"CarId": 0,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 14163229,
+			"LapTime": 370063,
+			"Sectors": [
+				298437,
+				57955,
+				13671
+			],
+			"Cuts": 3,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Callum Jones",
+			"DriverGuid": "76561198020046073",
+			"CarId": 0,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 14289206,
+			"LapTime": 125978,
+			"Sectors": [
+				54474,
+				58054,
+				13450
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Callum Jones",
+			"DriverGuid": "76561198020046073",
+			"CarId": 0,
+			"CarModel": "ks_mclaren_650_gt3",
+			"Timestamp": 14425758,
+			"LapTime": 136551,
+			"Sectors": [
+				64105,
+				58113,
+				14333
+			],
+			"Cuts": 6,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		},
+		{
+			"DriverName": "Joseph Elton",
+			"DriverGuid": "76561198029578060",
+			"CarId": 6,
+			"CarModel": "ks_mercedes_amg_gt3",
+			"Timestamp": 14531984,
+			"LapTime": 196138,
+			"Sectors": [
+				126910,
+				56417,
+				12811
+			],
+			"Cuts": 0,
+			"BallastKG": 0,
+			"Tyre": "S",
+			"Restrictor": 0
+		}
+	],
+	"Events": [
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 18.7272,
+			"WorldPosition": {
+				"X": 851.0963,
+				"Y": -37.890053,
+				"Z": 514.4743
+			},
+			"RelPosition": {
+				"X": 0.000014424324,
+				"Y": -0.27795464,
+				"Z": 2.621011
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 26.008905,
+			"WorldPosition": {
+				"X": 502.36038,
+				"Y": -17.792723,
+				"Z": 241.19588
+			},
+			"RelPosition": {
+				"X": 0.5434321,
+				"Y": -0.28568408,
+				"Z": 2.5242138
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 3,
+			"Driver": {
+				"Name": "Seb",
+				"Team": "",
+				"Nation": "ITA",
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 31.699917,
+			"WorldPosition": {
+				"X": -204.63417,
+				"Y": 1.2078075,
+				"Z": -243.61008
+			},
+			"RelPosition": {
+				"X": -1.0077155,
+				"Y": 0.246124,
+				"Z": 1.825745
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 0,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "",
+				"Nation": "ABW",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 10.405316,
+			"WorldPosition": {
+				"X": 317.5392,
+				"Y": -1.2149031,
+				"Z": -215.9426
+			},
+			"RelPosition": {
+				"X": 0.54344785,
+				"Y": -0.2856845,
+				"Z": 2.524223
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 0,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "",
+				"Nation": "ABW",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 16.939104,
+			"WorldPosition": {
+				"X": 648.57446,
+				"Y": -30.959326,
+				"Z": 412.22354
+			},
+			"RelPosition": {
+				"X": 0.5434234,
+				"Y": -0.2856849,
+				"Z": 2.5242496
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 0,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "",
+				"Nation": "ABW",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 54.232437,
+			"WorldPosition": {
+				"X": 347.15805,
+				"Y": -4.771231,
+				"Z": -49.323895
+			},
+			"RelPosition": {
+				"X": 0.47046924,
+				"Y": -0.30418402,
+				"Z": 2.3737652
+			}
+		},
+		{
+			"Type": "COLLISION_WITH_ENV",
+			"CarId": 0,
+			"Driver": {
+				"Name": "Callum Jones",
+				"Team": "",
+				"Nation": "ABW",
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				]
+			},
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Name": "",
+				"Team": "",
+				"Nation": "",
+				"Guid": "",
+				"GuidsList": null
+			},
+			"ImpactSpeed": 89.3272,
+			"WorldPosition": {
+				"X": 42.48086,
+				"Y": -0.44100505,
+				"Z": -54.81167
+			},
+			"RelPosition": {
+				"X": 0.38156664,
+				"Y": -0.2874821,
+				"Z": 2.5061312
+			}
+		}
+	]
+}

--- a/fixtures/results/2019_3_2_20_48_QUALIFY.json
+++ b/fixtures/results/2019_3_2_20_48_QUALIFY.json
@@ -1,0 +1,1520 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					""
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Argento_Nurburgring"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					""
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "12_carrera_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 3.4481761,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8726334,
+				"Y": 0.009840868,
+				"Z": -1.845053
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 99.4912,
+				"Y": -0.68025404,
+				"Z": 707.87445
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 41.323658,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7582626,
+				"Y": 0.06732882,
+				"Z": 2.0806212
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 341.26077,
+				"Y": -10.3295145,
+				"Z": 321.75922
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.23848,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.07931602,
+				"Y": -0.055294245,
+				"Z": 2.5751386
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 343.1826,
+				"Y": -7.748003,
+				"Z": 355.5595
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.523971,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.59326816,
+				"Y": -0.09772314,
+				"Z": -1.8515455
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 343.10892,
+				"Y": -7.7217207,
+				"Z": 355.58014
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.010284,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9369556,
+				"Y": -0.07468344,
+				"Z": 0.9083626
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 164.11401,
+				"Y": 5.312757,
+				"Z": 609.72156
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 21.739614,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.3763247,
+				"Y": -0.030625097,
+				"Z": 2.2685776
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 194.22424,
+				"Y": 6.9305124,
+				"Z": 579.99774
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 40.02642,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7846885,
+				"Y": 0.11835694,
+				"Z": 2.4270966
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 208.16618,
+				"Y": 7.1062746,
+				"Z": 596.93567
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 27.531704,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.052376,
+				"Y": 0.3593424,
+				"Z": 0.99950933
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 349.54358,
+				"Y": -10.715356,
+				"Z": 305.65845
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 94.74097,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.782713,
+				"Y": 0.116233096,
+				"Z": 2.4177246
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -370.9807,
+				"Y": 16.781279,
+				"Z": 840.7675
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 7.680085,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					""
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.76427066,
+				"Y": 0.27832294,
+				"Z": 1.8490028
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -363.5298,
+				"Y": 12.709884,
+				"Z": 191.78935
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					""
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.999591,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.96988446,
+				"Y": 0.15765344,
+				"Z": -0.22623976
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -363.4594,
+				"Y": 12.719616,
+				"Z": 191.93095
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 59.23574,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.5419191,
+				"Y": -0.21236464,
+				"Z": 2.2094166
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 103.05621,
+				"Y": -3.3374496,
+				"Z": 78.1993
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.414676,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8957843,
+				"Y": 0.24130149,
+				"Z": -0.7263129
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 206.03058,
+				"Y": -5.4474707,
+				"Z": 143.57832
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 25.261316,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.89031905,
+				"Y": 0.1535878,
+				"Z": 1.7694017
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 348.63605,
+				"Y": -10.713557,
+				"Z": 314.12927
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 106.91365,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.45802307,
+				"Y": 0.38255495,
+				"Z": -2.0296555
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -78.33531,
+				"Y": -16.3712,
+				"Z": 876.70087
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 42.98267,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.4754539,
+				"Y": 0.43887502,
+				"Z": -2.0616727
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -63.352352,
+				"Y": -16.49251,
+				"Z": 854.4915
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 39.754715,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.79672116,
+				"Y": -0.05505785,
+				"Z": 2.0263412
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -66.21568,
+				"Y": -17.24809,
+				"Z": 858.076
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 113023,
+			"Restrictor": 0,
+			"Sectors": [
+				87890,
+				25133
+			],
+			"Timestamp": 149122,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 125704,
+			"Restrictor": 0,
+			"Sectors": [
+				96481,
+				29223
+			],
+			"Timestamp": 210297,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 87540,
+			"Restrictor": 0,
+			"Sectors": [
+				62839,
+				24701
+			],
+			"Timestamp": 236663,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 98344,
+			"Restrictor": 0,
+			"Sectors": [
+				68307,
+				30037
+			],
+			"Timestamp": 308641,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 85945,
+			"Restrictor": 0,
+			"Sectors": [
+				60952,
+				24993
+			],
+			"Timestamp": 322606,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 109059,
+			"Restrictor": 0,
+			"Sectors": [
+				80250,
+				28809
+			],
+			"Timestamp": 380744,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 1,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 83647,
+			"Restrictor": 0,
+			"Sectors": [
+				58555,
+				25092
+			],
+			"Timestamp": 392288,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 72969,
+			"Restrictor": 0,
+			"Sectors": [
+				48722,
+				24247
+			],
+			"Timestamp": 395576,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 383117,
+			"Restrictor": 0,
+			"Sectors": [
+				359960,
+				23157
+			],
+			"Timestamp": 431000,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 82448,
+			"Restrictor": 0,
+			"Sectors": [
+				54711,
+				27737
+			],
+			"Timestamp": 463193,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 71681,
+			"Restrictor": 0,
+			"Sectors": [
+				46783,
+				24898
+			],
+			"Timestamp": 463967,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 73786,
+			"Restrictor": 0,
+			"Sectors": [
+				49239,
+				24547
+			],
+			"Timestamp": 469361,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 68204,
+			"Restrictor": 0,
+			"Sectors": [
+				45529,
+				22675
+			],
+			"Timestamp": 498970,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 2,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 75966,
+			"Restrictor": 0,
+			"Sectors": [
+				48435,
+				27531
+			],
+			"Timestamp": 545328,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 82658,
+			"Restrictor": 0,
+			"Sectors": [
+				56005,
+				26653
+			],
+			"Timestamp": 545847,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 66746,
+			"Restrictor": 0,
+			"Sectors": [
+				44337,
+				22409
+			],
+			"Timestamp": 565714,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 99825,
+			"Restrictor": 0,
+			"Sectors": [
+				75444,
+				24381
+			],
+			"Timestamp": 571851,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 77348,
+			"Restrictor": 0,
+			"Sectors": [
+				51213,
+				26135
+			],
+			"Timestamp": 623194,
+			"Tyre": "SM"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 68204,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 497689,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 71681,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 462694,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 72969,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 468086,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 77348,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 621919,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "shortcourse",
+	"TrackName": "road_atlanta2018",
+	"Type": "QUALIFY",
+	"Date": "2019-03-02T20:48:00Z",
+	"SessionFile": "2019_3_2_20_48_QUALIFY",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_21_21_QUALIFY.json
+++ b/fixtures/results/2019_3_2_21_21_QUALIFY.json
@@ -1,0 +1,1324 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Argento_Nurburgring"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 18.542278,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.59411484,
+				"Y": -0.33896056,
+				"Z": 2.3938358
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -5.811005,
+				"Y": 44.792027,
+				"Z": 208.14662
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.080041,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.26772493,
+				"Y": -0.07525219,
+				"Z": 2.4146066
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -145.16048,
+				"Y": 49.746273,
+				"Z": -99.72126
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.277805,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.49153316,
+				"Y": -0.08524662,
+				"Z": 2.2436502
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -23.283201,
+				"Y": 45.699642,
+				"Z": 211.3642
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.203583,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9614358,
+				"Y": 0.0034852177,
+				"Z": 1.0738004
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -23.369448,
+				"Y": 45.860977,
+				"Z": 211.21024
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 35.68195,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.44601697,
+				"Y": -0.21971717,
+				"Z": 2.5787513
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 39.42399,
+				"Y": 46.70047,
+				"Z": 221.31882
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 7.9172673,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0371108,
+				"Y": 0.2532033,
+				"Z": -1.0039403
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -42.280933,
+				"Y": 48.00404,
+				"Z": 155.38998
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 21.708887,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.753136,
+				"Y": -0.33792946,
+				"Z": 2.3337514
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 38.94663,
+				"Y": 46.773182,
+				"Z": 227.01897
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 31.520313,
+			"OtherCarId": 12,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.96808124,
+				"Y": -0.026201695,
+				"Z": -1.772821
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -198.21608,
+				"Y": 48.933544,
+				"Z": -720.9078
+			}
+		},
+		{
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.42692,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7714559,
+				"Y": 0.031207465,
+				"Z": 2.1077843
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -197.96587,
+				"Y": 48.91487,
+				"Z": -720.9955
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 124655,
+			"Restrictor": 0,
+			"Sectors": [
+				66813,
+				57842
+			],
+			"Timestamp": 165348,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 4,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 158639,
+			"Restrictor": 0,
+			"Sectors": [
+				96449,
+				62190
+			],
+			"Timestamp": 192074,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 161974,
+			"Restrictor": 0,
+			"Sectors": [
+				108865,
+				53109
+			],
+			"Timestamp": 201082,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 4,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 165025,
+			"Restrictor": 0,
+			"Sectors": [
+				98488,
+				66537
+			],
+			"Timestamp": 209194,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 109910,
+			"Restrictor": 0,
+			"Sectors": [
+				50753,
+				59157
+			],
+			"Timestamp": 275243,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 135510,
+			"Restrictor": 0,
+			"Sectors": [
+				72636,
+				62874
+			],
+			"Timestamp": 278286,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 101436,
+			"Restrictor": 0,
+			"Sectors": [
+				48650,
+				52786
+			],
+			"Timestamp": 302518,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 117731,
+			"Restrictor": 0,
+			"Sectors": [
+				53188,
+				64543
+			],
+			"Timestamp": 309808,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 107889,
+			"Restrictor": 0,
+			"Sectors": [
+				54087,
+				53802
+			],
+			"Timestamp": 317082,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 107408,
+			"Restrictor": 0,
+			"Sectors": [
+				51887,
+				55521
+			],
+			"Timestamp": 382650,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 118215,
+			"Restrictor": 0,
+			"Sectors": [
+				53279,
+				64936
+			],
+			"Timestamp": 396498,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 100259,
+			"Restrictor": 0,
+			"Sectors": [
+				48379,
+				51880
+			],
+			"Timestamp": 402775,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 107251,
+			"Restrictor": 0,
+			"Sectors": [
+				52324,
+				54927
+			],
+			"Timestamp": 417050,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 111879,
+			"Restrictor": 0,
+			"Sectors": [
+				56565,
+				55314
+			],
+			"Timestamp": 428967,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 119417,
+			"Restrictor": 0,
+			"Sectors": [
+				62015,
+				57402
+			],
+			"Timestamp": 431765,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 100344,
+			"Restrictor": 0,
+			"Sectors": [
+				48116,
+				52228
+			],
+			"Timestamp": 503117,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 113629,
+			"Restrictor": 0,
+			"Sectors": [
+				53734,
+				59895
+			],
+			"Timestamp": 510128,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 105840,
+			"Restrictor": 0,
+			"Sectors": [
+				50948,
+				54892
+			],
+			"Timestamp": 534799,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 136306,
+			"Restrictor": 0,
+			"Sectors": [
+				60337,
+				75969
+			],
+			"Timestamp": 553354,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 3,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 176061,
+			"Restrictor": 0,
+			"Sectors": [
+				110684,
+				65377
+			],
+			"Timestamp": 558712,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 107932,
+			"Restrictor": 0,
+			"Sectors": [
+				51704,
+				56228
+			],
+			"Timestamp": 666644,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 119701,
+			"Restrictor": 0,
+			"Sectors": [
+				56804,
+				62897
+			],
+			"Timestamp": 673053,
+			"Tyre": "V70"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 100259,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 501890,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 105840,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 533574,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 107251,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 671832,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 107932,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 665421,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 113629,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 508907,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "layout_sprint_b",
+	"TrackName": "ks_nurburgring",
+	"Type": "QUALIFY",
+	"Date": "2019-03-02T21:21:00Z",
+	"SessionFile": "2019_3_2_21_21_QUALIFY",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_21_36_RACE.json
+++ b/fixtures/results/2019_3_2_21_36_RACE.json
@@ -1,0 +1,2736 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Argento_Nurburgring"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 39.094646,
+			"OtherCarId": 12,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.22046942,
+				"Y": 0.028909057,
+				"Z": 2.290286
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -19.93755,
+				"Y": 53.62102,
+				"Z": -145.9279
+			}
+		},
+		{
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 39.90537,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.41375586,
+				"Y": -0.09921125,
+				"Z": -1.911791
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -19.930222,
+				"Y": 53.621746,
+				"Z": -146.01479
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 11.875026,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.92850596,
+				"Y": 0.10343917,
+				"Z": 1.7762165
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -42.159172,
+				"Y": 52.01675,
+				"Z": -121.81439
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.9451966,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8708201,
+				"Y": 0.19308236,
+				"Z": -0.77723074
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -42.188473,
+				"Y": 52.019783,
+				"Z": -121.7854
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.566836,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.51635367,
+				"Y": -0.014088921,
+				"Z": -1.9858334
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -214.78761,
+				"Y": 54.420834,
+				"Z": -237.52522
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.870226,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.38947755,
+				"Y": 0.03497096,
+				"Z": 2.274087
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -214.86636,
+				"Y": 54.44567,
+				"Z": -237.40239
+			}
+		},
+		{
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 14.794508,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.84590185,
+				"Y": 0.12969741,
+				"Z": 1.8989832
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -8.549445,
+				"Y": 65.1321,
+				"Z": -919.04645
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 27.207985,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.74266434,
+				"Y": -0.28352273,
+				"Z": 2.323432
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -5.5134254,
+				"Y": 64.94286,
+				"Z": -930.2989
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 21.892897,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.84947836,
+				"Y": -0.2639276,
+				"Z": 0.82611984
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -5.5154567,
+				"Y": 64.94241,
+				"Z": -929.9571
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.813642,
+			"OtherCarId": 12,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9053652,
+				"Y": 0.10593543,
+				"Z": 1.1134826
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -8.53854,
+				"Y": 65.14362,
+				"Z": -918.94727
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 35.86649,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0029845,
+				"Y": 0.11470459,
+				"Z": -1.8480765
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -16.960098,
+				"Y": 64.44094,
+				"Z": -846.7903
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 12.134497,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.000015616417,
+				"Y": 0.021000223,
+				"Z": 2.3114586
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -15.206701,
+				"Y": 62.505207,
+				"Z": -570.23676
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.040641572,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.00004470721,
+				"Y": 0.021001603,
+				"Z": 2.3114588
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -15.211935,
+				"Y": 62.52244,
+				"Z": -570.2432
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 17.414568,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.74025893,
+				"Y": -0.2762671,
+				"Z": 2.3216436
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -54.911613,
+				"Y": 50.592987,
+				"Z": -136.20073
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 5.37176,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7681393,
+				"Y": 0.10559672,
+				"Z": 2.3771882
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -55.406406,
+				"Y": 50.88729,
+				"Z": -136.00749
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.651996,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0029707,
+				"Y": 0.11470359,
+				"Z": -1.8480778
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -90.244736,
+				"Y": 51.62519,
+				"Z": -109.31307
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 32.78987,
+			"OtherCarId": 12,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.55451196,
+				"Y": -0.0042012604,
+				"Z": 2.2253792
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -16.758085,
+				"Y": 52.92172,
+				"Z": -114.36712
+			}
+		},
+		{
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 30.0817,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5017414,
+				"Y": -0.06312472,
+				"Z": 2.2547133
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -16.459616,
+				"Y": 52.920013,
+				"Z": -114.3293
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.94562477,
+			"OtherCarId": 12,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.82526594,
+				"Y": 0.14744733,
+				"Z": 1.2387986
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -16.974226,
+				"Y": 53.062443,
+				"Z": -119.982956
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.176018,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7531431,
+				"Y": -0.33792782,
+				"Z": 2.3337522
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -74.927986,
+				"Y": 51.397366,
+				"Z": -78.0888
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 187.16333,
+			"OtherCarId": 12,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.006248802,
+				"Y": 0.0312353,
+				"Z": 2.249955
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -22.737139,
+				"Y": 52.814323,
+				"Z": -127.11853
+			}
+		},
+		{
+			"CarId": 12,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 184.43976,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7301203,
+				"Y": -0.011246234,
+				"Z": -1.6173282
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -23.148249,
+				"Y": 52.79676,
+				"Z": -127.258995
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 45.27735,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.26772702,
+				"Y": -0.07525219,
+				"Z": 2.414605
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -44.370247,
+				"Y": 52.011753,
+				"Z": -138.8188
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 53.624336,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.48310763,
+				"Y": 0.07986483,
+				"Z": -2.0333033
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -61.591385,
+				"Y": 50.963203,
+				"Z": -152.75276
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 31.693771,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.90373546,
+				"Y": -0.28399107,
+				"Z": 1.8751855
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -66.4052,
+				"Y": 50.33559,
+				"Z": -153.84962
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 14.6790905,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.41335326,
+				"Y": 0.078642935,
+				"Z": 2.518771
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -66.41498,
+				"Y": 50.673813,
+				"Z": -153.91437
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.233119,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.88833475,
+				"Y": -0.26712742,
+				"Z": 1.2227057
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -66.56751,
+				"Y": 50.337013,
+				"Z": -153.97296
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 16.817375,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0005605,
+				"Y": 0.10572691,
+				"Z": -1.8457379
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -44.250366,
+				"Y": 52.076973,
+				"Z": -100.73863
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 34.61637,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.933162,
+				"Y": 0.11160381,
+				"Z": -1.8497572
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -44.299366,
+				"Y": 52.05592,
+				"Z": -100.77864
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 219.55276,
+			"OtherCarId": 13,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7531392,
+				"Y": -0.3379298,
+				"Z": 2.3337488
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -39.82771,
+				"Y": 51.736614,
+				"Z": -102.340126
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 129.94574,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.94686234,
+				"Y": -0.34824842,
+				"Z": -0.18666974
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -42.05288,
+				"Y": 52.53081,
+				"Z": -83.71655
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 199.72864,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8575623,
+				"Y": -0.28563473,
+				"Z": 1.1882828
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -39.530144,
+				"Y": 51.750984,
+				"Z": -101.89521
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 110.92213,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0488393,
+				"Y": 0.36228293,
+				"Z": 1.0086184
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -42.353203,
+				"Y": 52.46694,
+				"Z": -84.10977
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 63.873837,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.90399927,
+				"Y": -0.33399916,
+				"Z": 1.4163027
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -47.30218,
+				"Y": 52.52619,
+				"Z": -35.677143
+			}
+		},
+		{
+			"CarId": 13,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 51.10822,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.4754461,
+				"Y": 0.4388718,
+				"Z": -2.061699
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -64.56666,
+				"Y": 52.30019,
+				"Z": -55.46193
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.6961966,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8436349,
+				"Y": 0.093440555,
+				"Z": -0.18212335
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -69.785225,
+				"Y": 50.862392,
+				"Z": -136.48183
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.637684,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7859641,
+				"Y": 0.11970091,
+				"Z": 2.4330487
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -69.78588,
+				"Y": 50.86696,
+				"Z": -136.48225
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 27.822073,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.98289543,
+				"Y": 0.11470422,
+				"Z": -1.848078
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -151.89566,
+				"Y": 54.182297,
+				"Z": -233.62479
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 16.162987,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.5547012,
+				"Y": -0.0042031445,
+				"Z": 2.2253718
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -61.42354,
+				"Y": 50.71328,
+				"Z": -152.38422
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 2.6417935,
+			"OtherCarId": 4,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.82790667,
+				"Y": 0.026703224,
+				"Z": -1.2146415
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -63.21272,
+				"Y": 50.654316,
+				"Z": -141.74022
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.097206,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.4050244,
+				"Y": -0.26062438,
+				"Z": 2.598421
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -71.57716,
+				"Y": 50.56206,
+				"Z": -171.44257
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 2.6076248,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0112256,
+				"Y": -0.003489851,
+				"Z": -1.0055783
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -63.210712,
+				"Y": 50.668953,
+				"Z": -141.75197
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 15.688271,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5762212,
+				"Y": -0.33907554,
+				"Z": 2.4005952
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -73.63849,
+				"Y": 50.600716,
+				"Z": -175.89908
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 110073,
+			"Restrictor": 0,
+			"Sectors": [
+				57067,
+				53006
+			],
+			"Timestamp": 933134,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 115799,
+			"Restrictor": 0,
+			"Sectors": [
+				60238,
+				55561
+			],
+			"Timestamp": 938857,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 118114,
+			"Restrictor": 0,
+			"Sectors": [
+				61045,
+				57069
+			],
+			"Timestamp": 941190,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 120158,
+			"Restrictor": 0,
+			"Sectors": [
+				65690,
+				54468
+			],
+			"Timestamp": 943216,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 120161,
+			"Restrictor": 0,
+			"Sectors": [
+				67385,
+				52776
+			],
+			"Timestamp": 943223,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 134493,
+			"Restrictor": 0,
+			"Sectors": [
+				63294,
+				71199
+			],
+			"Timestamp": 957553,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 106289,
+			"Restrictor": 0,
+			"Sectors": [
+				53374,
+				52915
+			],
+			"Timestamp": 1039420,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 102688,
+			"Restrictor": 0,
+			"Sectors": [
+				50043,
+				52645
+			],
+			"Timestamp": 1045909,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 107089,
+			"Restrictor": 0,
+			"Sectors": [
+				51465,
+				55624
+			],
+			"Timestamp": 1045946,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 106557,
+			"Restrictor": 0,
+			"Sectors": [
+				50783,
+				55774
+			],
+			"Timestamp": 1047748,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 109870,
+			"Restrictor": 0,
+			"Sectors": [
+				51892,
+				57978
+			],
+			"Timestamp": 1053083,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 112135,
+			"Restrictor": 0,
+			"Sectors": [
+				55133,
+				57002
+			],
+			"Timestamp": 1069686,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 102764,
+			"Restrictor": 0,
+			"Sectors": [
+				49862,
+				52902
+			],
+			"Timestamp": 1142181,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 100882,
+			"Restrictor": 0,
+			"Sectors": [
+				48984,
+				51898
+			],
+			"Timestamp": 1146789,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 106363,
+			"Restrictor": 0,
+			"Sectors": [
+				51189,
+				55174
+			],
+			"Timestamp": 1152310,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 109084,
+			"Restrictor": 0,
+			"Sectors": [
+				52960,
+				56124
+			],
+			"Timestamp": 1156831,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 105544,
+			"Restrictor": 0,
+			"Sectors": [
+				50630,
+				54914
+			],
+			"Timestamp": 1158625,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 112861,
+			"Restrictor": 0,
+			"Sectors": [
+				53835,
+				59026
+			],
+			"Timestamp": 1182545,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 103458,
+			"Restrictor": 0,
+			"Sectors": [
+				50079,
+				53379
+			],
+			"Timestamp": 1245638,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 100301,
+			"Restrictor": 0,
+			"Sectors": [
+				48210,
+				52091
+			],
+			"Timestamp": 1247087,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 109931,
+			"Restrictor": 0,
+			"Sectors": [
+				50684,
+				59247
+			],
+			"Timestamp": 1262239,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 106705,
+			"Restrictor": 0,
+			"Sectors": [
+				51670,
+				55035
+			],
+			"Timestamp": 1263536,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 105675,
+			"Restrictor": 0,
+			"Sectors": [
+				51224,
+				54451
+			],
+			"Timestamp": 1264299,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 112947,
+			"Restrictor": 0,
+			"Sectors": [
+				53673,
+				59274
+			],
+			"Timestamp": 1295491,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 183587,
+			"Restrictor": 0,
+			"Sectors": [
+				130254,
+				53333
+			],
+			"Timestamp": 1322009,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 101999,
+			"Restrictor": 0,
+			"Sectors": [
+				49016,
+				52983
+			],
+			"Timestamp": 1349084,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 105407,
+			"Restrictor": 0,
+			"Sectors": [
+				50139,
+				55268
+			],
+			"Timestamp": 1351042,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 105635,
+			"Restrictor": 0,
+			"Sectors": [
+				50699,
+				54936
+			],
+			"Timestamp": 1367873,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 106721,
+			"Restrictor": 0,
+			"Sectors": [
+				52488,
+				54233
+			],
+			"Timestamp": 1371017,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 113950,
+			"Restrictor": 0,
+			"Sectors": [
+				58893,
+				55057
+			],
+			"Timestamp": 1377486,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 126220,
+			"Restrictor": 0,
+			"Sectors": [
+				56632,
+				69588
+			],
+			"Timestamp": 1421709,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 103268,
+			"Restrictor": 0,
+			"Sectors": [
+				50358,
+				52910
+			],
+			"Timestamp": 1425293,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 101684,
+			"Restrictor": 0,
+			"Sectors": [
+				49710,
+				51974
+			],
+			"Timestamp": 1450764,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 103799,
+			"Restrictor": 0,
+			"Sectors": [
+				49601,
+				54198
+			],
+			"Timestamp": 1454837,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 104290,
+			"Restrictor": 0,
+			"Sectors": [
+				49876,
+				54414
+			],
+			"Timestamp": 1472163,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 105328,
+			"Restrictor": 0,
+			"Sectors": [
+				49618,
+				55710
+			],
+			"Timestamp": 1482813,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 119343,
+			"Restrictor": 0,
+			"Sectors": [
+				57395,
+				61948
+			],
+			"Timestamp": 1490358,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 102841,
+			"Restrictor": 0,
+			"Sectors": [
+				50132,
+				52709
+			],
+			"Timestamp": 1528115,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 137827,
+			"Restrictor": 0,
+			"Sectors": [
+				57354,
+				80473
+			],
+			"Timestamp": 1559533,
+			"Tyre": "SM"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 100301,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 627696,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 102764,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 631771,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 104290,
+			"CarId": 0,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 649102,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 105328,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 659741,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 105544,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 667296,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 112135,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 736471,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 102841,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 704985,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "layout_sprint_b",
+	"TrackName": "ks_nurburgring",
+	"Type": "RACE",
+	"Date": "2019-03-02T21:36:00Z",
+	"SessionFile": "2019_3_2_21_36_RACE",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_21_49_QUALIFY.json
+++ b/fixtures/results/2019_3_2_21_49_QUALIFY.json
@@ -1,0 +1,2620 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					"76561198437072463"
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					"76561198365646634"
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					""
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 3.4596066,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.06182,
+				"Y": 0.42115015,
+				"Z": 0.78120726
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -82.11017,
+				"Y": 5.2242184,
+				"Z": 372.9922
+			}
+		},
+		{
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 18.330818,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9588042,
+				"Y": -0.119409926,
+				"Z": -1.0309438
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -85.2096,
+				"Y": 5.2810855,
+				"Z": 354.99478
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 23.515629,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.27980423,
+				"Y": -0.10858263,
+				"Z": -1.9046298
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -88.74069,
+				"Y": 4.919533,
+				"Z": 382.33865
+			}
+		},
+		{
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 46.403378,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.960501,
+				"Y": -0.2639836,
+				"Z": -1.0496056
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 671.3677,
+				"Y": 2.49896,
+				"Z": 68.04241
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 31.24352,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.40420747,
+				"Y": -0.13817638,
+				"Z": 2.5619392
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -88.741135,
+				"Y": 4.9266987,
+				"Z": 382.29172
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					"76561198365646634"
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 44.08058,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7531396,
+				"Y": -0.25777528,
+				"Z": 2.4668858
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -252.87401,
+				"Y": 7.892081,
+				"Z": 28.513966
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 53.941162,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.40504396,
+				"Y": -0.3401828,
+				"Z": 2.4652991
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 639.5377,
+				"Y": -6.4124155,
+				"Z": 155.32301
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.076889,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.0618303,
+				"Y": 0.36228234,
+				"Z": 1.0086217
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 550.0641,
+				"Y": -8.876603,
+				"Z": 224.56955
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.968531,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0273305,
+				"Y": 0.34762108,
+				"Z": 0.64361054
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 550.2631,
+				"Y": -8.875664,
+				"Z": 224.5125
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.087461,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.002975,
+				"Y": 0.11470608,
+				"Z": -1.8480747
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -253.11035,
+				"Y": 8.347797,
+				"Z": 28.379944
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 61.071697,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.9197418,
+				"Y": -0.25077108,
+				"Z": -1.2273545
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 631.898,
+				"Y": 3.1410034,
+				"Z": 37.97196
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 53.444782,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.0053220987,
+				"Y": -0.25576723,
+				"Z": 2.633796
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 631.8672,
+				"Y": 3.1153967,
+				"Z": 38.224266
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 70.24515,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.40501606,
+				"Y": -0.34018025,
+				"Z": 2.4652996
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -262.906,
+				"Y": 8.518117,
+				"Z": 22.781559
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.6203675,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.6354965,
+				"Y": 0.2201055,
+				"Z": -1.4963211
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -83.12829,
+				"Y": 5.112513,
+				"Z": 371.9643
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.39239,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.03949946,
+				"Y": -0.115679756,
+				"Z": -2.0003524
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 67.01412,
+				"Y": 3.1010642,
+				"Z": -20.582636
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 26.648136,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.23387921,
+				"Y": -0.06850241,
+				"Z": 2.5451326
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 67.16325,
+				"Y": 3.049012,
+				"Z": -20.813665
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 7.2500153,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.81933147,
+				"Y": 0.2769497,
+				"Z": 1.2484288
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 141.04803,
+				"Y": -11.764014,
+				"Z": 333.6731
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 28.949938,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.40499365,
+				"Y": -0.34018284,
+				"Z": 2.4653058
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 528.66394,
+				"Y": -9.399206,
+				"Z": 248.89313
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.3917828,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.76444626,
+				"Y": 0.27832356,
+				"Z": 1.8490113
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 61.724037,
+				"Y": -7.701953,
+				"Z": 352.9893
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 40.87872,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7531419,
+				"Y": -0.33792984,
+				"Z": 2.3337407
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -256.5494,
+				"Y": 8.090948,
+				"Z": 26.381516
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 15.448443,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.2677287,
+				"Y": -0.075251,
+				"Z": 2.414592
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -76.54756,
+				"Y": 3.9989588,
+				"Z": 383.15363
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.5178733,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.78594345,
+				"Y": 0.039387245,
+				"Z": 2.2981675
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -111.53546,
+				"Y": 7.343877,
+				"Z": 430.43973
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 54.973114,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7771702,
+				"Y": -0.045661706,
+				"Z": -1.382614
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 545.8572,
+				"Y": -8.688885,
+				"Z": 245.48264
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.51755,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.635494,
+				"Y": 0.22010534,
+				"Z": -1.496328
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 441.8475,
+				"Y": -10.812998,
+				"Z": 248.50237
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 102.47527,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.93286204,
+				"Y": 0.0018701442,
+				"Z": 1.7754714
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -75.59137,
+				"Y": 3.873283,
+				"Z": 405.27777
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 33.73157,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.0000042915344,
+				"Y": -0.3396025,
+				"Z": 2.5021923
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -61.859505,
+				"Y": 2.915883,
+				"Z": 416.17844
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 111.832794,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.48650712,
+				"Y": -0.18413615,
+				"Z": 2.2361999
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -75.494484,
+				"Y": 3.6153605,
+				"Z": 405.2506
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 1.229967,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.293173,
+				"Y": -0.3017311,
+				"Z": -1.4648188
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 441.54178,
+				"Y": -11.340387,
+				"Z": 248.60202
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 22.237503,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5137629,
+				"Y": 0.03942673,
+				"Z": 2.2621512
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 597.1134,
+				"Y": -8.620743,
+				"Z": 192.36179
+			}
+		},
+		{
+			"CarId": 16,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 72.806984,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.38887668,
+				"Y": -0.13965902,
+				"Z": 2.298734
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 51.212345,
+				"Y": -6.94435,
+				"Z": 366.27838
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 91.31936,
+			"OtherCarId": 16,
+			"OtherDriver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.12476914,
+				"Y": -0.16057822,
+				"Z": -1.3349594
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 51.064587,
+				"Y": -6.870232,
+				"Z": 366.06497
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 72374,
+			"Restrictor": 0,
+			"Sectors": [
+				45748,
+				26626
+			],
+			"Timestamp": 98145,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 90131,
+			"Restrictor": 0,
+			"Sectors": [
+				64333,
+				25798
+			],
+			"Timestamp": 123792,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 88125,
+			"Restrictor": 0,
+			"Sectors": [
+				61034,
+				27091
+			],
+			"Timestamp": 127923,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 89754,
+			"Restrictor": 0,
+			"Sectors": [
+				53808,
+				35946
+			],
+			"Timestamp": 130708,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 86194,
+			"Restrictor": 0,
+			"Sectors": [
+				57358,
+				28836
+			],
+			"Timestamp": 145661,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 112866,
+			"Restrictor": 0,
+			"Sectors": [
+				79741,
+				33125
+			],
+			"Timestamp": 152716,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 60545,
+			"Restrictor": 0,
+			"Sectors": [
+				34122,
+				26423
+			],
+			"Timestamp": 158686,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58197,
+			"Restrictor": 0,
+			"Sectors": [
+				32493,
+				25704
+			],
+			"Timestamp": 181988,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 97755,
+			"Restrictor": 0,
+			"Sectors": [
+				67145,
+				30610
+			],
+			"Timestamp": 184914,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 75167,
+			"Restrictor": 0,
+			"Sectors": [
+				48176,
+				26991
+			],
+			"Timestamp": 203088,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 61987,
+			"Restrictor": 0,
+			"Sectors": [
+				35325,
+				26662
+			],
+			"Timestamp": 214701,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 84307,
+			"Restrictor": 0,
+			"Sectors": [
+				46250,
+				38057
+			],
+			"Timestamp": 215015,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 77122,
+			"Restrictor": 0,
+			"Sectors": [
+				37365,
+				39757
+			],
+			"Timestamp": 222783,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 2,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59089,
+			"Restrictor": 0,
+			"Sectors": [
+				33083,
+				26006
+			],
+			"Timestamp": 241076,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62297,
+			"Restrictor": 0,
+			"Sectors": [
+				34744,
+				27553
+			],
+			"Timestamp": 247202,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 62777,
+			"Restrictor": 0,
+			"Sectors": [
+				35444,
+				27333
+			],
+			"Timestamp": 265861,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 97444,
+			"Restrictor": 0,
+			"Sectors": [
+				69926,
+				27518
+			],
+			"Timestamp": 267996,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 1,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 60756,
+			"Restrictor": 0,
+			"Sectors": [
+				34579,
+				26177
+			],
+			"Timestamp": 275772,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 63447,
+			"Restrictor": 0,
+			"Sectors": [
+				36919,
+				26528
+			],
+			"Timestamp": 278147,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 76245,
+			"Restrictor": 0,
+			"Sectors": [
+				48434,
+				27811
+			],
+			"Timestamp": 299032,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59023,
+			"Restrictor": 0,
+			"Sectors": [
+				33252,
+				25771
+			],
+			"Timestamp": 300097,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62804,
+			"Restrictor": 0,
+			"Sectors": [
+				35273,
+				27531
+			],
+			"Timestamp": 310004,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 81073,
+			"Restrictor": 0,
+			"Sectors": [
+				52975,
+				28098
+			],
+			"Timestamp": 322636,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 60360,
+			"Restrictor": 0,
+			"Sectors": [
+				34053,
+				26307
+			],
+			"Timestamp": 328354,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 66585,
+			"Restrictor": 0,
+			"Sectors": [
+				39018,
+				27567
+			],
+			"Timestamp": 332445,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 61564,
+			"Restrictor": 0,
+			"Sectors": [
+				35005,
+				26559
+			],
+			"Timestamp": 337336,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60538,
+			"Restrictor": 0,
+			"Sectors": [
+				34460,
+				26078
+			],
+			"Timestamp": 338685,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58577,
+			"Restrictor": 0,
+			"Sectors": [
+				33036,
+				25541
+			],
+			"Timestamp": 358671,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 62081,
+			"Restrictor": 0,
+			"Sectors": [
+				35117,
+				26964
+			],
+			"Timestamp": 361104,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 64910,
+			"Restrictor": 0,
+			"Sectors": [
+				36484,
+				28426
+			],
+			"Timestamp": 374912,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 65871,
+			"Restrictor": 0,
+			"Sectors": [
+				38713,
+				27158
+			],
+			"Timestamp": 398316,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 64400,
+			"Restrictor": 0,
+			"Sectors": [
+				38427,
+				25973
+			],
+			"Timestamp": 403088,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 64087,
+			"Restrictor": 0,
+			"Sectors": [
+				32393,
+				31694
+			],
+			"Timestamp": 422757,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 3,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 86847,
+			"Restrictor": 0,
+			"Sectors": [
+				46387,
+				40460
+			],
+			"Timestamp": 424183,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 64433,
+			"Restrictor": 0,
+			"Sectors": [
+				36750,
+				27683
+			],
+			"Timestamp": 425535,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 2,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 204899,
+			"Restrictor": 0,
+			"Sectors": [
+				164642,
+				40257
+			],
+			"Timestamp": 429639,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 61859,
+			"Restrictor": 0,
+			"Sectors": [
+				34923,
+				26936
+			],
+			"Timestamp": 436770,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 91621,
+			"Restrictor": 0,
+			"Sectors": [
+				64824,
+				26797
+			],
+			"Timestamp": 449534,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 60655,
+			"Restrictor": 0,
+			"Sectors": [
+				33876,
+				26779
+			],
+			"Timestamp": 458969,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 145516,
+			"Restrictor": 0,
+			"Sectors": [
+				110713,
+				34803
+			],
+			"Timestamp": 473870,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 3,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 65458,
+			"Restrictor": 0,
+			"Sectors": [
+				39273,
+				26185
+			],
+			"Timestamp": 488213,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 1,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 67099,
+			"Restrictor": 0,
+			"Sectors": [
+				35554,
+				31545
+			],
+			"Timestamp": 491282,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 79792,
+			"Restrictor": 0,
+			"Sectors": [
+				36376,
+				43416
+			],
+			"Timestamp": 505325,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 5,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 107237,
+			"Restrictor": 0,
+			"Sectors": [
+				56194,
+				51043
+			],
+			"Timestamp": 510315,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 61057,
+			"Restrictor": 0,
+			"Sectors": [
+				34332,
+				26725
+			],
+			"Timestamp": 510588,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61322,
+			"Restrictor": 0,
+			"Sectors": [
+				33841,
+				27481
+			],
+			"Timestamp": 520289,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 60567,
+			"Restrictor": 0,
+			"Sectors": [
+				34116,
+				26451
+			],
+			"Timestamp": 534456,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58299,
+			"Restrictor": 0,
+			"Sectors": [
+				32653,
+				25646
+			],
+			"Timestamp": 546512,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 59878,
+			"Restrictor": 0,
+			"Sectors": [
+				33153,
+				26725
+			],
+			"Timestamp": 551160,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 65278,
+			"Restrictor": 0,
+			"Sectors": [
+				37302,
+				27976
+			],
+			"Timestamp": 570602,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 64823,
+			"Restrictor": 0,
+			"Sectors": [
+				34872,
+				29951
+			],
+			"Timestamp": 575409,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 3,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 140614,
+			"Restrictor": 0,
+			"Sectors": [
+				96226,
+				44388
+			],
+			"Timestamp": 577383,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 2,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 62373,
+			"Restrictor": 0,
+			"Sectors": [
+				35413,
+				26960
+			],
+			"Timestamp": 582661,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 73848,
+			"Restrictor": 0,
+			"Sectors": [
+				45970,
+				27878
+			],
+			"Timestamp": 584163,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 60516,
+			"Restrictor": 0,
+			"Sectors": [
+				34069,
+				26447
+			],
+			"Timestamp": 594954,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 189021,
+			"Restrictor": 0,
+			"Sectors": [
+				162232,
+				26789
+			],
+			"Timestamp": 618656,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 63815,
+			"Restrictor": 0,
+			"Sectors": [
+				36366,
+				27449
+			],
+			"Timestamp": 634414,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 61137,
+			"Restrictor": 0,
+			"Sectors": [
+				34290,
+				26847
+			],
+			"Timestamp": 645298,
+			"Tyre": "SM"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 58197,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 545283,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 59878,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 549938,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 60360,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 593666,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 60655,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 519066,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61137,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 644072,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61859,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 435540,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 62081,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 633192,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 72374,
+			"CarId": 5,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 96849,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 91621,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 448238,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 189021,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 617432,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "layout_national",
+	"TrackName": "ks_red_bull_ring",
+	"Type": "QUALIFY",
+	"Date": "2019-03-02T21:49:00Z",
+	"SessionFile": "2019_3_2_21_49_QUALIFY",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_21_4_RACE.json
+++ b/fixtures/results/2019_3_2_21_4_RACE.json
@@ -1,0 +1,1928 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					""
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					""
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Argento_Nurburgring"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					""
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "12_carrera_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.245506,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.78595805,
+				"Y": 0.039386205,
+				"Z": 2.2981842
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 337.47366,
+				"Y": -9.342905,
+				"Z": 334.0582
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 23.33455,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.46135074,
+				"Y": 0.037888948,
+				"Z": 2.2632244
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 119.48544,
+				"Y": 3.602386,
+				"Z": 608.40356
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 93.99738,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7796812,
+				"Y": 0.03254054,
+				"Z": 2.2683103
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -372.3561,
+				"Y": 16.759512,
+				"Z": 839.4282
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 11.575833,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.000009434298,
+				"Y": 0.02099806,
+				"Z": 2.3114219
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -205.51936,
+				"Y": -4.0964437,
+				"Z": 956.89215
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 58.248055,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.9078875,
+				"Y": 0.14932533,
+				"Z": -0.5796213
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 392.36182,
+				"Y": -11.456185,
+				"Z": 294.39423
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 61.18317,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.82921624,
+				"Y": 0.31166998,
+				"Z": -0.5896139
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 51.47633,
+				"Y": -1.3451948,
+				"Z": 45.277203
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 11.944935,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.47545153,
+				"Y": 0.43887287,
+				"Z": -2.0617037
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 99.42345,
+				"Y": -2.4284506,
+				"Z": 75.82876
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 26.496397,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.754289,
+				"Y": -0.053788655,
+				"Z": 2.0941443
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 147.19011,
+				"Y": -4.492675,
+				"Z": 106.252945
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 25.00765,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7250676,
+				"Y": -0.08441716,
+				"Z": 2.074926
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -84.23594,
+				"Y": -16.541346,
+				"Z": 884.10474
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.132443,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.6663108,
+				"Y": -0.09347161,
+				"Z": -1.8271179
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -88.331245,
+				"Y": -16.191883,
+				"Z": 889.03125
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 44.95503,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.748965,
+				"Y": 0.027728407,
+				"Z": 2.2681112
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 351.3514,
+				"Y": -11.066508,
+				"Z": 310.14713
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.127973,
+			"OtherCarId": 6,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					""
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5227216,
+				"Y": -0.010529488,
+				"Z": 2.2386231
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -336.22775,
+				"Y": 8.570851,
+				"Z": 291.50876
+			}
+		},
+		{
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					""
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.576664,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					""
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.6575319,
+				"Y": -0.26483682,
+				"Z": -0.4538347
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -336.53696,
+				"Y": 8.513263,
+				"Z": 293.70697
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 45.0264,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.94368994,
+				"Y": 0.15626273,
+				"Z": -1.2444124
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -63.108425,
+				"Y": 3.557945,
+				"Z": -54.179726
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					""
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 52.866833,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7793544,
+				"Y": 0.03210375,
+				"Z": 2.2664547
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 353.3642,
+				"Y": -11.434663,
+				"Z": 300.88672
+			}
+		},
+		{
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					""
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 45.857872,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.4035101,
+				"Y": -0.34405965,
+				"Z": 2.4484196
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 354.35977,
+				"Y": -12.172672,
+				"Z": 281.01334
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.350677,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7714395,
+				"Y": 0.031208891,
+				"Z": 2.1077933
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 27.258234,
+				"Y": -0.1833095,
+				"Z": -1.9857945
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					""
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 12.220794,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.72866845,
+				"Y": -0.034977205,
+				"Z": -1.6889089
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 59.541283,
+				"Y": -1.5393885,
+				"Z": 18.720987
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 74161,
+			"Restrictor": 0,
+			"Sectors": [
+				51314,
+				22847
+			],
+			"Timestamp": 903740,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 82432,
+			"Restrictor": 0,
+			"Sectors": [
+				56678,
+				25754
+			],
+			"Timestamp": 912003,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 85200,
+			"Restrictor": 0,
+			"Sectors": [
+				57416,
+				27784
+			],
+			"Timestamp": 914770,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 111341,
+			"Restrictor": 0,
+			"Sectors": [
+				85111,
+				26230
+			],
+			"Timestamp": 940916,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 130310,
+			"Restrictor": 0,
+			"Sectors": [
+				94846,
+				35464
+			],
+			"Timestamp": 959877,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 71326,
+			"Restrictor": 0,
+			"Sectors": [
+				44159,
+				27167
+			],
+			"Timestamp": 975065,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 75304,
+			"Restrictor": 0,
+			"Sectors": [
+				49802,
+				25502
+			],
+			"Timestamp": 987306,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 88857,
+			"Restrictor": 0,
+			"Sectors": [
+				48221,
+				40636
+			],
+			"Timestamp": 1003628,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 69869,
+			"Restrictor": 0,
+			"Sectors": [
+				46253,
+				23616
+			],
+			"Timestamp": 1010782,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 67064,
+			"Restrictor": 0,
+			"Sectors": [
+				44614,
+				22450
+			],
+			"Timestamp": 1042126,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 100946,
+			"Restrictor": 0,
+			"Sectors": [
+				70823,
+				30123
+			],
+			"Timestamp": 1060819,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 75862,
+			"Restrictor": 0,
+			"Sectors": [
+				50626,
+				25236
+			],
+			"Timestamp": 1063164,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 75626,
+			"Restrictor": 0,
+			"Sectors": [
+				50444,
+				25182
+			],
+			"Timestamp": 1079252,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 74536,
+			"Restrictor": 0,
+			"Sectors": [
+				50241,
+				24295
+			],
+			"Timestamp": 1085316,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 66890,
+			"Restrictor": 0,
+			"Sectors": [
+				44584,
+				22306
+			],
+			"Timestamp": 1109111,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 79571,
+			"Restrictor": 0,
+			"Sectors": [
+				54349,
+				25222
+			],
+			"Timestamp": 1140387,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 85559,
+			"Restrictor": 0,
+			"Sectors": [
+				51958,
+				33601
+			],
+			"Timestamp": 1148722,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 74550,
+			"Restrictor": 0,
+			"Sectors": [
+				49359,
+				25191
+			],
+			"Timestamp": 1153802,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 76766,
+			"Restrictor": 0,
+			"Sectors": [
+				52817,
+				23949
+			],
+			"Timestamp": 1162079,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 66769,
+			"Restrictor": 0,
+			"Sectors": [
+				44130,
+				22639
+			],
+			"Timestamp": 1175781,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 75328,
+			"Restrictor": 0,
+			"Sectors": [
+				50614,
+				24714
+			],
+			"Timestamp": 1224047,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 73930,
+			"Restrictor": 0,
+			"Sectors": [
+				49347,
+				24583
+			],
+			"Timestamp": 1227734,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 74369,
+			"Restrictor": 0,
+			"Sectors": [
+				50983,
+				23386
+			],
+			"Timestamp": 1236445,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 66930,
+			"Restrictor": 0,
+			"Sectors": [
+				44043,
+				22887
+			],
+			"Timestamp": 1242711,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 112386,
+			"Restrictor": 0,
+			"Sectors": [
+				87145,
+				25241
+			],
+			"Timestamp": 1252772,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 73599,
+			"Restrictor": 0,
+			"Sectors": [
+				48120,
+				25479
+			],
+			"Timestamp": 1297646,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 72145,
+			"Restrictor": 0,
+			"Sectors": [
+				47773,
+				24372
+			],
+			"Timestamp": 1299878,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 67266,
+			"Restrictor": 0,
+			"Sectors": [
+				44649,
+				22617
+			],
+			"Timestamp": 1309975,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 78410,
+			"Restrictor": 0,
+			"Sectors": [
+				54673,
+				23737
+			],
+			"Timestamp": 1314853,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 95094,
+			"Restrictor": 0,
+			"Sectors": [
+				69961,
+				25133
+			],
+			"Timestamp": 1347865,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 81946,
+			"Restrictor": 0,
+			"Sectors": [
+				55360,
+				26586
+			],
+			"Timestamp": 1381821,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 86710,
+			"Restrictor": 0,
+			"Sectors": [
+				57946,
+				28764
+			],
+			"Timestamp": 1384353,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 73794,
+			"Restrictor": 0,
+			"Sectors": [
+				50376,
+				23418
+			],
+			"Timestamp": 1388646,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 80239,
+			"Restrictor": 0,
+			"Sectors": [
+				45225,
+				35014
+			],
+			"Timestamp": 1390213,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 73256,
+			"Restrictor": 0,
+			"Sectors": [
+				48785,
+				24471
+			],
+			"Timestamp": 1455075,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 109007,
+			"Restrictor": 0,
+			"Sectors": [
+				56848,
+				52159
+			],
+			"Timestamp": 1456884,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 68822,
+			"Restrictor": 0,
+			"Sectors": [
+				45567,
+				23255
+			],
+			"Timestamp": 1457465,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 67384,
+			"Restrictor": 0,
+			"Sectors": [
+				44380,
+				23004
+			],
+			"Timestamp": 1457594,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 73500,
+			"Restrictor": 0,
+			"Sectors": [
+				48264,
+				25236
+			],
+			"Timestamp": 1457852,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 72858,
+			"Restrictor": 0,
+			"Sectors": [
+				47311,
+				25547
+			],
+			"Timestamp": 1527934,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 77718,
+			"Restrictor": 0,
+			"Sectors": [
+				54695,
+				23023
+			],
+			"Timestamp": 1535182,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 85295,
+			"Restrictor": 0,
+			"Sectors": [
+				57823,
+				27472
+			],
+			"Timestamp": 1542161,
+			"Tyre": "V70"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 66769,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 628012,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 72145,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 698358,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 68822,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 705603,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 73500,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 628276,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 79571,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 712586,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "shortcourse",
+	"TrackName": "road_atlanta2018",
+	"Type": "RACE",
+	"Date": "2019-03-02T21:04:00Z",
+	"SessionFile": "2019_3_2_21_4_RACE",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_22_15_QUALIFY.json
+++ b/fixtures/results/2019_3_2_22_15_QUALIFY.json
@@ -1,0 +1,2084 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					"76561198437072463"
+				],
+				"Name": "rich p",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					"76561198365646634"
+				],
+				"Name": "Cheezypoof",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.208012,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.770637,
+				"Y": 0.03156123,
+				"Z": 2.1065946
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 880.6847,
+				"Y": -38.984524,
+				"Z": 548.5211
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 42.370678,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.0376282,
+				"Y": 0.25316912,
+				"Z": -1.0038949
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 432.46927,
+				"Y": -17.26613,
+				"Z": 81.658394
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 2.3292015,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7518393,
+				"Y": -0.25798073,
+				"Z": 2.4633703
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 431.48233,
+				"Y": -17.673098,
+				"Z": 85.09106
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 1.7273932,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.82837784,
+				"Y": -0.021093488,
+				"Z": 2.24126
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 431.46,
+				"Y": -16.891727,
+				"Z": 85.17174
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 30.361473,
+			"OtherCarId": 10,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.6262179,
+				"Y": -0.3164721,
+				"Z": 1.241302
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 429.9293,
+				"Y": -17.499622,
+				"Z": 84.47097
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.947628,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8619413,
+				"Y": -0.29390463,
+				"Z": 1.7960964
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 430.91074,
+				"Y": -18.035736,
+				"Z": 87.15836
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 46.672718,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.30221856,
+				"Y": 0.66334796,
+				"Z": 0.5874342
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 430.31238,
+				"Y": -17.078253,
+				"Z": 85.66811
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.129903,
+			"OtherCarId": 10,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.3648863,
+				"Y": -0.25902927,
+				"Z": 2.553715
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 430.33582,
+				"Y": -17.117569,
+				"Z": 85.67888
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.1745076,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.93745446,
+				"Y": -0.29018098,
+				"Z": 1.8765396
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 431.53217,
+				"Y": -17.21572,
+				"Z": 84.830414
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 18.47808,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8671918,
+				"Y": -0.29545838,
+				"Z": 1.7993759
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 430.94147,
+				"Y": -17.263313,
+				"Z": 81.97111
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.841875,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.40502715,
+				"Y": -0.26062295,
+				"Z": 2.5984235
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 329.60495,
+				"Y": -1.9889579,
+				"Z": -118.05477
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 128.27638,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.94752896,
+				"Y": -0.26441064,
+				"Z": -0.54707783
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 528.2595,
+				"Y": -16.5767,
+				"Z": -76.93758
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 30.158163,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5137355,
+				"Y": 0.039426297,
+				"Z": 2.2621727
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 1015.14514,
+				"Y": -40.457607,
+				"Z": 518.61237
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.210459,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0029753,
+				"Y": 0.11470533,
+				"Z": -1.8480852
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 454.6029,
+				"Y": -15.763637,
+				"Z": 240.63354
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.060513,
+			"OtherCarId": 10,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.0323999,
+				"Y": 0.21087149,
+				"Z": -1.0133661
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 402.2142,
+				"Y": -15.356009,
+				"Z": 171.58939
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.7570353,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9039753,
+				"Y": 0.18978673,
+				"Z": 1.5610628
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 399.6484,
+				"Y": -15.566014,
+				"Z": 163.83081
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.327225,
+			"OtherCarId": 10,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.9139701,
+				"Y": -0.26706657,
+				"Z": 1.9019012
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 425.1303,
+				"Y": -15.261997,
+				"Z": 28.401909
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.065868,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9070022,
+				"Y": -0.17091325,
+				"Z": 1.1707482
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 425.1153,
+				"Y": -15.232496,
+				"Z": 28.199049
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.316111,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7859765,
+				"Y": 0.039384842,
+				"Z": 2.2981675
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 734.5443,
+				"Y": -27.534115,
+				"Z": 193.0971
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 47.079132,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.782428,
+				"Y": 0.11593743,
+				"Z": 2.416308
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 439.4286,
+				"Y": -13.3221035,
+				"Z": 14.565399
+			}
+		},
+		{
+			"CarId": 18,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 35.786575,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8595867,
+				"Y": -0.23198149,
+				"Z": -0.441666
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 959.6878,
+				"Y": -42.73399,
+				"Z": 534.8381
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 37.02332,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.77143675,
+				"Y": 0.0312098,
+				"Z": 2.1078157
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 851.09686,
+				"Y": -37.515785,
+				"Z": 514.4321
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 31.278883,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7531507,
+				"Y": -0.33792892,
+				"Z": 2.3337357
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 1013.32855,
+				"Y": -40.79059,
+				"Z": 527.4942
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 2,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 81230,
+			"Restrictor": 0,
+			"Sectors": [
+				49411,
+				31819
+			],
+			"Timestamp": 122084,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 85146,
+			"Restrictor": 0,
+			"Sectors": [
+				53141,
+				32005
+			],
+			"Timestamp": 122935,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 85668,
+			"Restrictor": 0,
+			"Sectors": [
+				56683,
+				28985
+			],
+			"Timestamp": 126625,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 95577,
+			"Restrictor": 0,
+			"Sectors": [
+				68185,
+				27392
+			],
+			"Timestamp": 137542,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 99370,
+			"Restrictor": 0,
+			"Sectors": [
+				59487,
+				39883
+			],
+			"Timestamp": 157979,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 129830,
+			"Restrictor": 0,
+			"Sectors": [
+				100387,
+				29443
+			],
+			"Timestamp": 160095,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60893,
+			"Restrictor": 0,
+			"Sectors": [
+				32521,
+				28372
+			],
+			"Timestamp": 183825,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 1,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 64906,
+			"Restrictor": 0,
+			"Sectors": [
+				36394,
+				28512
+			],
+			"Timestamp": 186990,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 62073,
+			"Restrictor": 0,
+			"Sectors": [
+				33074,
+				28999
+			],
+			"Timestamp": 188697,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58216,
+			"Restrictor": 0,
+			"Sectors": [
+				31193,
+				27023
+			],
+			"Timestamp": 195756,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 63466,
+			"Restrictor": 0,
+			"Sectors": [
+				33838,
+				29628
+			],
+			"Timestamp": 223560,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 74620,
+			"Restrictor": 0,
+			"Sectors": [
+				35205,
+				39415
+			],
+			"Timestamp": 232595,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 66684,
+			"Restrictor": 0,
+			"Sectors": [
+				38838,
+				27846
+			],
+			"Timestamp": 250508,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59199,
+			"Restrictor": 0,
+			"Sectors": [
+				31830,
+				27369
+			],
+			"Timestamp": 254954,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 4,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 89928,
+			"Restrictor": 0,
+			"Sectors": [
+				41890,
+				48038
+			],
+			"Timestamp": 278624,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 3,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 94695,
+			"Restrictor": 0,
+			"Sectors": [
+				33868,
+				60827
+			],
+			"Timestamp": 281683,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62385,
+			"Restrictor": 0,
+			"Sectors": [
+				33162,
+				29223
+			],
+			"Timestamp": 285945,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 3,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 62360,
+			"Restrictor": 0,
+			"Sectors": [
+				33885,
+				28475
+			],
+			"Timestamp": 312866,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59498,
+			"Restrictor": 0,
+			"Sectors": [
+				32300,
+				27198
+			],
+			"Timestamp": 314450,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 2,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 90577,
+			"Restrictor": 0,
+			"Sectors": [
+				34493,
+				56084
+			],
+			"Timestamp": 323170,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 64156,
+			"Restrictor": 0,
+			"Sectors": [
+				35153,
+				29003
+			],
+			"Timestamp": 345838,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62279,
+			"Restrictor": 0,
+			"Sectors": [
+				32931,
+				29348
+			],
+			"Timestamp": 348223,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60087,
+			"Restrictor": 0,
+			"Sectors": [
+				32367,
+				27720
+			],
+			"Timestamp": 372952,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58754,
+			"Restrictor": 0,
+			"Sectors": [
+				31736,
+				27018
+			],
+			"Timestamp": 373201,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 98023,
+			"Restrictor": 0,
+			"Sectors": [
+				69849,
+				28174
+			],
+			"Timestamp": 376645,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 68235,
+			"Restrictor": 0,
+			"Sectors": [
+				36708,
+				31527
+			],
+			"Timestamp": 391404,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 61206,
+			"Restrictor": 0,
+			"Sectors": [
+				32932,
+				28274
+			],
+			"Timestamp": 407045,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62503,
+			"Restrictor": 0,
+			"Sectors": [
+				33118,
+				29385
+			],
+			"Timestamp": 410725,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 61451,
+			"Restrictor": 0,
+			"Sectors": [
+				33137,
+				28314
+			],
+			"Timestamp": 434401,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 64326,
+			"Restrictor": 0,
+			"Sectors": [
+				37064,
+				27262
+			],
+			"Timestamp": 437526,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 1,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 77930,
+			"Restrictor": 0,
+			"Sectors": [
+				35410,
+				42520
+			],
+			"Timestamp": 469330,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 1,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 99802,
+			"Restrictor": 0,
+			"Sectors": [
+				65278,
+				34524
+			],
+			"Timestamp": 476445,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 1,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 71460,
+			"Restrictor": 0,
+			"Sectors": [
+				35923,
+				35537
+			],
+			"Timestamp": 478506,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 1,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 70196,
+			"Restrictor": 0,
+			"Sectors": [
+				33116,
+				37080
+			],
+			"Timestamp": 480919,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59057,
+			"Restrictor": 0,
+			"Sectors": [
+				31927,
+				27130
+			],
+			"Timestamp": 496580,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 66274,
+			"Restrictor": 0,
+			"Sectors": [
+				34788,
+				31486
+			],
+			"Timestamp": 535604,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 60958,
+			"Restrictor": 0,
+			"Sectors": [
+				32793,
+				28165
+			],
+			"Timestamp": 537402,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 61864,
+			"Restrictor": 0,
+			"Sectors": [
+				33154,
+				28710
+			],
+			"Timestamp": 542783,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 1,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 78349,
+			"Restrictor": 0,
+			"Sectors": [
+				36530,
+				41819
+			],
+			"Timestamp": 556854,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 3,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 122542,
+			"Restrictor": 0,
+			"Sectors": [
+				83032,
+				39510
+			],
+			"Timestamp": 556939,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 67033,
+			"Restrictor": 0,
+			"Sectors": [
+				35448,
+				31585
+			],
+			"Timestamp": 602635,
+			"Tyre": "SM"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 58216,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 495278,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 60087,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 433121,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 60958,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 536119,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61206,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 405769,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61864,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 541501,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 66274,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 601358,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 4,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 2,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "suzukaeast",
+	"TrackName": "suzuka",
+	"Type": "QUALIFY",
+	"Date": "2019-03-02T22:15:00Z",
+	"SessionFile": "2019_3_2_22_15_QUALIFY",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_22_28_RACE.json
+++ b/fixtures/results/2019_3_2_22_28_RACE.json
@@ -1,0 +1,2120 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					"76561198437072463"
+				],
+				"Name": "rich p",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					"76561198365646634"
+				],
+				"Name": "Cheezypoof",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.274994,
+			"OtherCarId": 9,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9493474,
+				"Y": -0.1772775,
+				"Z": -0.50101185
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 731.3208,
+				"Y": -26.340197,
+				"Z": 141.48248
+			}
+		},
+		{
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 35.802395,
+			"OtherCarId": 10,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.82416636,
+				"Y": -0.18334407,
+				"Z": -1.5189974
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 731.3822,
+				"Y": -26.350153,
+				"Z": 141.50735
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.04724604,
+			"OtherCarId": 18,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.09260625,
+				"Y": -0.22828183,
+				"Z": -1.9417348
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 672.60394,
+				"Y": -32.71208,
+				"Z": 394.6068
+			}
+		},
+		{
+			"CarId": 18,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.9622092,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.0000923574,
+				"Y": -0.07723366,
+				"Z": 2.4312825
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 673.09375,
+				"Y": -32.728104,
+				"Z": 394.9637
+			}
+		},
+		{
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 5.1747684,
+			"OtherCarId": 5,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9231553,
+				"Y": 0.18566407,
+				"Z": 1.1496537
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 318.17624,
+				"Y": -1.5074056,
+				"Z": -108.65015
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.0861115,
+			"OtherCarId": 9,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.010175,
+				"Y": 0.18538913,
+				"Z": -0.87796223
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 318.17493,
+				"Y": -1.4920442,
+				"Z": -108.639046
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 14.583844,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7780968,
+				"Y": 0.031857852,
+				"Z": 2.4402232
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 959.93976,
+				"Y": -42.45596,
+				"Z": 534.0925
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.226295,
+			"OtherCarId": 9,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.93989664,
+				"Y": 0.018473051,
+				"Z": -1.174458
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 874.05597,
+				"Y": -38.877777,
+				"Z": 571.55273
+			}
+		},
+		{
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 31.032682,
+			"OtherCarId": 10,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7586524,
+				"Y": 0.017954648,
+				"Z": 2.0891225
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 874.09625,
+				"Y": -38.89613,
+				"Z": 571.54816
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 18.212961,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7714222,
+				"Y": 0.031207677,
+				"Z": 2.1077607
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 819.7805,
+				"Y": -37.148586,
+				"Z": 561.0042
+			}
+		},
+		{
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.461843,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7531311,
+				"Y": -0.3379306,
+				"Z": 2.3337069
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 972.1922,
+				"Y": -41.874866,
+				"Z": 483.02713
+			}
+		},
+		{
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 15.259357,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.96013355,
+				"Y": 0.11289532,
+				"Z": -0.6887216
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 963.2201,
+				"Y": -41.728924,
+				"Z": 562.36316
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.878339,
+			"OtherCarId": 9,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.9960668,
+				"Y": 0.25453144,
+				"Z": 1.3268081
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": 963.06335,
+				"Y": -41.66753,
+				"Z": 562.5592
+			}
+		},
+		{
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 90.43727,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7714079,
+				"Y": 0.031207928,
+				"Z": 2.1077886
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 1015.6104,
+				"Y": -40.448257,
+				"Z": 516.2672
+			}
+		},
+		{
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.7225127,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7714232,
+				"Y": 0.03120906,
+				"Z": 2.1077783
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 1011.8523,
+				"Y": -40.470596,
+				"Z": 534.69403
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 129.45352,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.6565897,
+				"Y": -0.23697315,
+				"Z": 2.0269265
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 1022.6137,
+				"Y": -40.4104,
+				"Z": 485.11365
+			}
+		},
+		{
+			"CarId": 10,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 57.04306,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.96553004,
+				"Y": -0.26382154,
+				"Z": -1.2430332
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 850.11346,
+				"Y": -37.75909,
+				"Z": 512.9045
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60998,
+			"Restrictor": 0,
+			"Sectors": [
+				33089,
+				27909
+			],
+			"Timestamp": 832951,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 62696,
+			"Restrictor": 0,
+			"Sectors": [
+				34189,
+				28507
+			],
+			"Timestamp": 834645,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 65614,
+			"Restrictor": 0,
+			"Sectors": [
+				36967,
+				28647
+			],
+			"Timestamp": 837570,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 66348,
+			"Restrictor": 0,
+			"Sectors": [
+				37804,
+				28544
+			],
+			"Timestamp": 838302,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 67035,
+			"Restrictor": 0,
+			"Sectors": [
+				36408,
+				30627
+			],
+			"Timestamp": 838987,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 67164,
+			"Restrictor": 0,
+			"Sectors": [
+				38759,
+				28405
+			],
+			"Timestamp": 839138,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60437,
+			"Restrictor": 0,
+			"Sectors": [
+				32646,
+				27791
+			],
+			"Timestamp": 893386,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 60682,
+			"Restrictor": 0,
+			"Sectors": [
+				32404,
+				28278
+			],
+			"Timestamp": 898982,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 60029,
+			"Restrictor": 0,
+			"Sectors": [
+				32008,
+				28021
+			],
+			"Timestamp": 899165,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 63672,
+			"Restrictor": 0,
+			"Sectors": [
+				33823,
+				29849
+			],
+			"Timestamp": 901242,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 68907,
+			"Restrictor": 0,
+			"Sectors": [
+				40295,
+				28612
+			],
+			"Timestamp": 903552,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 66289,
+			"Restrictor": 0,
+			"Sectors": [
+				36773,
+				29516
+			],
+			"Timestamp": 905276,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59798,
+			"Restrictor": 0,
+			"Sectors": [
+				32002,
+				27796
+			],
+			"Timestamp": 953181,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 60986,
+			"Restrictor": 0,
+			"Sectors": [
+				33982,
+				27004
+			],
+			"Timestamp": 960148,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 61703,
+			"Restrictor": 0,
+			"Sectors": [
+				33142,
+				28561
+			],
+			"Timestamp": 962943,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 62970,
+			"Restrictor": 0,
+			"Sectors": [
+				33270,
+				29700
+			],
+			"Timestamp": 968243,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 72262,
+			"Restrictor": 0,
+			"Sectors": [
+				44511,
+				27751
+			],
+			"Timestamp": 971243,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 71410,
+			"Restrictor": 0,
+			"Sectors": [
+				41962,
+				29448
+			],
+			"Timestamp": 974962,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59789,
+			"Restrictor": 0,
+			"Sectors": [
+				32038,
+				27751
+			],
+			"Timestamp": 1012968,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58462,
+			"Restrictor": 0,
+			"Sectors": [
+				31322,
+				27140
+			],
+			"Timestamp": 1018610,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62202,
+			"Restrictor": 0,
+			"Sectors": [
+				33289,
+				28913
+			],
+			"Timestamp": 1025146,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 63688,
+			"Restrictor": 0,
+			"Sectors": [
+				33898,
+				29790
+			],
+			"Timestamp": 1031931,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 60931,
+			"Restrictor": 0,
+			"Sectors": [
+				32630,
+				28301
+			],
+			"Timestamp": 1032172,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 62627,
+			"Restrictor": 0,
+			"Sectors": [
+				33747,
+				28880
+			],
+			"Timestamp": 1037597,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59708,
+			"Restrictor": 0,
+			"Sectors": [
+				31930,
+				27778
+			],
+			"Timestamp": 1072673,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58127,
+			"Restrictor": 0,
+			"Sectors": [
+				31272,
+				26855
+			],
+			"Timestamp": 1076733,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62095,
+			"Restrictor": 0,
+			"Sectors": [
+				33232,
+				28863
+			],
+			"Timestamp": 1087242,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 60594,
+			"Restrictor": 0,
+			"Sectors": [
+				32208,
+				28386
+			],
+			"Timestamp": 1092765,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 63726,
+			"Restrictor": 0,
+			"Sectors": [
+				33724,
+				30002
+			],
+			"Timestamp": 1095661,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 64051,
+			"Restrictor": 0,
+			"Sectors": [
+				32339,
+				31712
+			],
+			"Timestamp": 1101638,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60757,
+			"Restrictor": 0,
+			"Sectors": [
+				32934,
+				27823
+			],
+			"Timestamp": 1133429,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58237,
+			"Restrictor": 0,
+			"Sectors": [
+				31359,
+				26878
+			],
+			"Timestamp": 1134968,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 61885,
+			"Restrictor": 0,
+			"Sectors": [
+				32928,
+				28957
+			],
+			"Timestamp": 1149126,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 62073,
+			"Restrictor": 0,
+			"Sectors": [
+				32768,
+				29305
+			],
+			"Timestamp": 1154837,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 77044,
+			"Restrictor": 0,
+			"Sectors": [
+				34541,
+				42503
+			],
+			"Timestamp": 1172699,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59608,
+			"Restrictor": 0,
+			"Sectors": [
+				31627,
+				27981
+			],
+			"Timestamp": 1193034,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58375,
+			"Restrictor": 0,
+			"Sectors": [
+				31092,
+				27283
+			],
+			"Timestamp": 1193342,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61497,
+			"Restrictor": 0,
+			"Sectors": [
+				32580,
+				28917
+			],
+			"Timestamp": 1216334,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 73500,
+			"Restrictor": 0,
+			"Sectors": [
+				44047,
+				29453
+			],
+			"Timestamp": 1222629,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 72023,
+			"Restrictor": 0,
+			"Sectors": [
+				40415,
+				31608
+			],
+			"Timestamp": 1244719,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 61161,
+			"Restrictor": 0,
+			"Sectors": [
+				32783,
+				28378
+			],
+			"Timestamp": 1254502,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 61777,
+			"Restrictor": 0,
+			"Sectors": [
+				32851,
+				28926
+			],
+			"Timestamp": 1254811,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61452,
+			"Restrictor": 0,
+			"Sectors": [
+				32949,
+				28503
+			],
+			"Timestamp": 1277785,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62181,
+			"Restrictor": 0,
+			"Sectors": [
+				33471,
+				28710
+			],
+			"Timestamp": 1284807,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 66594,
+			"Restrictor": 0,
+			"Sectors": [
+				36227,
+				30367
+			],
+			"Timestamp": 1311312,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 62851,
+			"Restrictor": 0,
+			"Sectors": [
+				35558,
+				27293
+			],
+			"Timestamp": 1317353,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 63338,
+			"Restrictor": 0,
+			"Sectors": [
+				35731,
+				27607
+			],
+			"Timestamp": 1318145,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61627,
+			"Restrictor": 0,
+			"Sectors": [
+				32535,
+				29092
+			],
+			"Timestamp": 1339411,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 70640,
+			"Restrictor": 0,
+			"Sectors": [
+				33111,
+				37529
+			],
+			"Timestamp": 1355445,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 65704,
+			"Restrictor": 0,
+			"Sectors": [
+				33817,
+				31887
+			],
+			"Timestamp": 1377014,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60005,
+			"Restrictor": 0,
+			"Sectors": [
+				32051,
+				27954
+			],
+			"Timestamp": 1378147,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 69485,
+			"Restrictor": 0,
+			"Sectors": [
+				31974,
+				37511
+			],
+			"Timestamp": 1386834,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 66664,
+			"Restrictor": 0,
+			"Sectors": [
+				36402,
+				30262
+			],
+			"Timestamp": 1406073,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62440,
+			"Restrictor": 0,
+			"Sectors": [
+				33343,
+				29097
+			],
+			"Timestamp": 1417884,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 68901,
+			"Restrictor": 0,
+			"Sectors": [
+				35592,
+				33309
+			],
+			"Timestamp": 1445915,
+			"Tyre": "SM"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 59608,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 606189,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 58127,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 614873,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 60594,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 634118,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61703,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 645925,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 62970,
+			"CarId": 5,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 673959,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 62627,
+			"CarId": 1,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 329685,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 4,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 2,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "suzukaeast",
+	"TrackName": "suzuka",
+	"Type": "RACE",
+	"Date": "2019-03-02T22:28:00Z",
+	"SessionFile": "2019_3_2_22_28_RACE",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/fixtures/results/2019_3_2_22_3_RACE.json
+++ b/fixtures/results/2019_3_2_22_3_RACE.json
@@ -1,0 +1,4472 @@
+{
+	"Cars": [
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Viola_Ophelia"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Silver"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 3,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					"76561198045844392"
+				],
+				"Name": "Spaceman9795",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 4,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					"76561198437072463"
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "a3dr_lambo_diablo_vt",
+			"Restrictor": 0,
+			"Skin": "Blu_Oscuro"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 5,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					"76561198365646634"
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "a3dr_ferrari_512tr",
+			"Restrictor": 0,
+			"Skin": "Giallo_Modena"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 6,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "03_kunosracing_17"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 9,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "01_racing_red"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 10,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 11,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "11_carrera_lime"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 12,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "10_carrera_grey"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 13,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_porsche_911_carrera_rsr",
+			"Restrictor": 0,
+			"Skin": "21_kunosracing_75"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					""
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 17,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 18,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 20,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 21,
+			"Driver": {
+				"Guid": "",
+				"GuidsList": [
+					""
+				],
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"Model": "ks_alfa_33_stradale",
+			"Restrictor": 0,
+			"Skin": "00_rosso"
+		}
+	],
+	"Events": [
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 60.151325,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8929572,
+				"Y": 0.19191818,
+				"Z": 1.7670182
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -261.67056,
+				"Y": 8.919584,
+				"Z": 23.479906
+			}
+		},
+		{
+			"CarId": 16,
+			"Driver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.7579006,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8338914,
+				"Y": 0.03970459,
+				"Z": -1.1850265
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -189.51445,
+				"Y": 3.5808847,
+				"Z": 42.479992
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 7.2466393,
+			"OtherCarId": 16,
+			"OtherDriver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.788803,
+				"Y": -0.051797982,
+				"Z": 2.2685122
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -189.5225,
+				"Y": 3.5618987,
+				"Z": 42.53072
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.164434,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8488104,
+				"Y": -0.18180327,
+				"Z": 2.0543165
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -274.1923,
+				"Y": 7.5828037,
+				"Z": 113.08818
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.685852,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.98529994,
+				"Y": -0.074490674,
+				"Z": -1.2714918
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -274.1873,
+				"Y": 7.8141065,
+				"Z": 113.03572
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.95239,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0029825,
+				"Y": 0.11470597,
+				"Z": -1.8480824
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -269.58817,
+				"Y": 9.283741,
+				"Z": 23.860826
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 5.5364323,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.9828891,
+				"Y": 0.11470581,
+				"Z": -1.8480811
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -268.29575,
+				"Y": 9.324921,
+				"Z": 19.706554
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.19631,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9584526,
+				"Y": 0.07306049,
+				"Z": -1.407486
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -269.55066,
+				"Y": 9.279741,
+				"Z": 23.914267
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.952705,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.78597134,
+				"Y": 0.11969936,
+				"Z": 2.4330282
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -267.67563,
+				"Y": 9.2146,
+				"Z": 20.068031
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.50892,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.26773274,
+				"Y": -0.07525164,
+				"Z": 2.4145794
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -260.52338,
+				"Y": 7.8806734,
+				"Z": 60.956448
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 11.218829,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8175962,
+				"Y": 0.2386778,
+				"Z": 1.2449865
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -192.88681,
+				"Y": 3.9854534,
+				"Z": 39.799446
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 26.766272,
+			"OtherCarId": 19,
+			"OtherDriver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.98438007,
+				"Y": 0.15120523,
+				"Z": 0.4913641
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -163.28918,
+				"Y": 1.9320467,
+				"Z": 66.846756
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 24.419199,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.76426,
+				"Y": 0.27832302,
+				"Z": 1.8490052
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -163.20607,
+				"Y": 1.934947,
+				"Z": 66.939926
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 37.83473,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7859706,
+				"Y": 0.03938737,
+				"Z": 2.2981796
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -250.04205,
+				"Y": 8.087604,
+				"Z": 30.118235
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.983585,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.75313985,
+				"Y": -0.3379301,
+				"Z": 2.33375
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 1.5827987,
+				"Y": 3.935679,
+				"Z": -22.583578
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 44.64223,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.77143013,
+				"Y": 0.031209026,
+				"Z": 2.107809
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -102.78479,
+				"Y": 6.3716707,
+				"Z": 317.2829
+			}
+		},
+		{
+			"CarId": 15,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					""
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 23.996357,
+			"OtherCarId": 16,
+			"OtherDriver": {
+				"Guid": "76561198365646634",
+				"GuidsList": [
+					""
+				],
+				"Name": "Cheezypoof",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7881047,
+				"Y": -0.11047131,
+				"Z": -1.2807758
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -98.60322,
+				"Y": 5.5790386,
+				"Z": 373.3994
+			}
+		},
+		{
+			"CarId": 15,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					""
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 22.088165,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8397838,
+				"Y": 0.04364412,
+				"Z": -1.1753184
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -106.250145,
+				"Y": 6.444098,
+				"Z": 310.7157
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 11.4801035,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7531461,
+				"Y": -0.25777435,
+				"Z": 2.4668899
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -221.82883,
+				"Y": 6.7115088,
+				"Z": 18.638765
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 52.47059,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.80535245,
+				"Y": 0.048095927,
+				"Z": 2.2271874
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -249.9529,
+				"Y": 8.051628,
+				"Z": 30.170914
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 32.512924,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.777323,
+				"Y": -0.04566363,
+				"Z": -1.3826513
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 607.6385,
+				"Y": 1.8698356,
+				"Z": 57.80841
+			}
+		},
+		{
+			"CarId": 19,
+			"Driver": {
+				"Guid": "76561198020046073",
+				"GuidsList": [
+					"76561198020046073"
+				],
+				"Name": "Callum Jones",
+				"Nation": "ABW",
+				"Team": ""
+			},
+			"ImpactSpeed": 30.403107,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7644508,
+				"Y": 0.2783232,
+				"Z": 1.8490088
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 607.95355,
+				"Y": 1.8318199,
+				"Z": 61.93704
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.93299,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0029705,
+				"Y": 0.114706226,
+				"Z": -1.8480825
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -246.27867,
+				"Y": 7.675321,
+				"Z": 46.942017
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.964302,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.51375085,
+				"Y": 0.039426386,
+				"Z": 2.262146
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -33.53648,
+				"Y": 2.3873506,
+				"Z": 30.821192
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 47.52934,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.40499622,
+				"Y": -0.3401801,
+				"Z": 2.4653006
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": 554.79584,
+				"Y": -9.634177,
+				"Z": 213.61081
+			}
+		},
+		{
+			"CarId": 15,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					""
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 25.797651,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7771783,
+				"Y": -0.045663007,
+				"Z": -1.382657
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -256.84503,
+				"Y": 8.401481,
+				"Z": 26.218225
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 3.7860413,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8929633,
+				"Y": 0.1919197,
+				"Z": 1.7670436
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -118.90106,
+				"Y": 8.079986,
+				"Z": 432.57657
+			}
+		},
+		{
+			"CarId": 15,
+			"Driver": {
+				"Guid": "76561198437072463",
+				"GuidsList": [
+					""
+				],
+				"Name": "rich p",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 19.565325,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5545147,
+				"Y": -0.00420139,
+				"Z": 2.2253757
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -241.82867,
+				"Y": 7.649433,
+				"Z": 26.85688
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 5.8333716,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8926878,
+				"Y": 0.19192792,
+				"Z": 1.7669395
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -120.49291,
+				"Y": 8.195454,
+				"Z": 433.0098
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 208.04527,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.5726485,
+				"Y": -0.17318496,
+				"Z": 2.3892708
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -125.08344,
+				"Y": 7.97045,
+				"Z": 422.88522
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 109.596054,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.48311728,
+				"Y": 0.079864554,
+				"Z": -2.0332959
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -155.75008,
+				"Y": 10.691232,
+				"Z": 428.7087
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 57.33579,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.0044783,
+				"Y": 0.2864175,
+				"Z": -0.66210705
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -155.83632,
+				"Y": 10.9676485,
+				"Z": 437.2277
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 33.481716,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8063765,
+				"Y": -0.12922801,
+				"Z": 1.9518377
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -153.3954,
+				"Y": 10.366754,
+				"Z": 436.4096
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 29.874668,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.47544488,
+				"Y": 0.43887338,
+				"Z": -2.0616958
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -157.91148,
+				"Y": 11.191903,
+				"Z": 433.64728
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 20.628216,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.75858414,
+				"Y": -0.0334175,
+				"Z": 2.0977073
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -155.02846,
+				"Y": 10.634883,
+				"Z": 437.40915
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 22.242691,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.4491886,
+				"Y": -0.03031699,
+				"Z": 2.2949402
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -153.26666,
+				"Y": 10.334529,
+				"Z": 436.27655
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 212.07497,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.79995793,
+				"Y": -0.18203239,
+				"Z": -1.1682969
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -125.39172,
+				"Y": 7.9315853,
+				"Z": 422.70438
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 20.820036,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.40502143,
+				"Y": -0.26062307,
+				"Z": 2.5984004
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -154.84471,
+				"Y": 10.345164,
+				"Z": 441.95435
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 55.3255,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8507536,
+				"Y": 0.117051594,
+				"Z": -1.7332517
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -155.88245,
+				"Y": 10.784434,
+				"Z": 437.27927
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 17.353468,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.27431127,
+				"Y": 0.009841822,
+				"Z": -1.8450598
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -154.8284,
+				"Y": 10.614723,
+				"Z": 437.38107
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 3.9263742,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.98290235,
+				"Y": 0.11470618,
+				"Z": -1.8480711
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -156.04315,
+				"Y": 10.846758,
+				"Z": 438.73694
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 13.8442955,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.4831252,
+				"Y": 0.079863995,
+				"Z": -2.0332792
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -155.96997,
+				"Y": 10.781507,
+				"Z": 436.20627
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.012167076,
+			"OtherCarId": 14,
+			"OtherDriver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.14010495,
+				"Y": 0.026450079,
+				"Z": 2.2931013
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -152.37148,
+				"Y": 10.4214735,
+				"Z": 436.88293
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 12.510661,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9439887,
+				"Y": 0.120106846,
+				"Z": -0.83350706
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -155.9379,
+				"Y": 10.788488,
+				"Z": 436.2193
+			}
+		},
+		{
+			"CarId": 14,
+			"Driver": {
+				"Guid": "76561198045844392",
+				"GuidsList": [
+					""
+				],
+				"Name": "Spaceman9795",
+				"Nation": "USA",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.888293,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8429633,
+				"Y": -0.25584397,
+				"Z": 0.76378095
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -152.21939,
+				"Y": 10.089093,
+				"Z": 436.4476
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 6.6065187,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.85524315,
+				"Y": 0.10990144,
+				"Z": -1.8228945
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -155.85612,
+				"Y": 10.839186,
+				"Z": 437.39645
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 7.0252166,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -1.0029786,
+				"Y": -0.2807202,
+				"Z": -1.7505336
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -154.43533,
+				"Y": 10.270536,
+				"Z": 426.14966
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 4.07245,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 1.0476648,
+				"Y": 0.35515678,
+				"Z": 0.65042937
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -154.73566,
+				"Y": 10.885412,
+				"Z": 433.07996
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 10.610559,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9346254,
+				"Y": 0.15596303,
+				"Z": -1.2384216
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -154.95769,
+				"Y": 10.717422,
+				"Z": 433.83246
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 152.5637,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.87033576,
+				"Y": -0.18769015,
+				"Z": 1.6011555
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -152.4925,
+				"Y": 10.206379,
+				"Z": 436.09396
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 65.09792,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.42879808,
+				"Y": 0.29894054,
+				"Z": -1.7982403
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -157.17609,
+				"Y": 11.171963,
+				"Z": 437.84497
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 66.07118,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.89857495,
+				"Y": -0.22570662,
+				"Z": -1.373745
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -159.44006,
+				"Y": 10.497653,
+				"Z": 436.9085
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 177.34915,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.51375073,
+				"Y": 0.039425522,
+				"Z": 2.262154
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -136.95294,
+				"Y": 9.23824,
+				"Z": 433.24948
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 121.54132,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.76110685,
+				"Y": -0.020680673,
+				"Z": 2.099689
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -153.20627,
+				"Y": 10.558446,
+				"Z": 436.44324
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 32.721474,
+			"OtherCarId": 2,
+			"OtherDriver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.6782271,
+				"Y": 0.056191966,
+				"Z": 2.0357244
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -154.8453,
+				"Y": 10.784038,
+				"Z": 437.71323
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 92.664604,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.47544444,
+				"Y": 0.43887326,
+				"Z": -2.0617042
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -158.38455,
+				"Y": 11.312611,
+				"Z": 434.4338
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 196.0419,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7918957,
+				"Y": -0.28072026,
+				"Z": -1.7505438
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -137.17503,
+				"Y": 8.95841,
+				"Z": 433.2197
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 22.139364,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.78596735,
+				"Y": 0.03938595,
+				"Z": 2.29819
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -140.57243,
+				"Y": 9.613563,
+				"Z": 438.40848
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 23.275885,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.89219034,
+				"Y": -0.09828663,
+				"Z": -1.7184621
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -156.07387,
+				"Y": 11.1435795,
+				"Z": 437.5752
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 120.560486,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7558801,
+				"Y": 0.21606196,
+				"Z": -1.7522763
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -154.25186,
+				"Y": 10.808504,
+				"Z": 437.4832
+			}
+		},
+		{
+			"CarId": 2,
+			"Driver": {
+				"Guid": "76561198023931313",
+				"GuidsList": [
+					"76561198023931313"
+				],
+				"Name": "Danny Wilson",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 14.722476,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 5.066395e-7,
+				"Y": -0.26021084,
+				"Z": 2.635321
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -154.972,
+				"Y": 10.327267,
+				"Z": 441.98355
+			}
+		},
+		{
+			"CarId": 0,
+			"Driver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"ImpactSpeed": 25.608603,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.7500482,
+				"Y": -0.29149005,
+				"Z": 2.322259
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -146.17607,
+				"Y": 9.652548,
+				"Z": 433.87454
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.089698,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.37662733,
+				"Y": -0.26381376,
+				"Z": -1.243058
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -158.09119,
+				"Y": 11.318608,
+				"Z": 438.1805
+			}
+		},
+		{
+			"CarId": 7,
+			"Driver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"ImpactSpeed": 1.5732777,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.96550643,
+				"Y": -0.26382113,
+				"Z": -1.2430785
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -159.71603,
+				"Y": 10.633289,
+				"Z": 437.5311
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 2.0968513,
+			"OtherCarId": 7,
+			"OtherDriver": {
+				"Guid": "76561198029578060",
+				"GuidsList": [
+					"76561198029578060"
+				],
+				"Name": "Joseph Elton",
+				"Nation": "GBR",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.4891746,
+				"Y": 0.43232647,
+				"Z": -2.024809
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -157.75905,
+				"Y": 11.261579,
+				"Z": 437.76495
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 3.4712164,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.8929589,
+				"Y": 0.19192089,
+				"Z": 1.7670469
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -144.16994,
+				"Y": 10.033469,
+				"Z": 439.29456
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 9.827558,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.87976086,
+				"Y": -0.2966022,
+				"Z": 1.5720578
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -144.2318,
+				"Y": 9.498784,
+				"Z": 437.49704
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 25.620605,
+			"OtherCarId": 0,
+			"OtherDriver": {
+				"Guid": "76561198074322763",
+				"GuidsList": [
+					"76561198074322763"
+				],
+				"Name": "Seb",
+				"Nation": "ITA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.9303588,
+				"Y": 0.3876351,
+				"Z": -1.0479064
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -145.73595,
+				"Y": 10.280885,
+				"Z": 434.49033
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 11.638,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.7483559,
+				"Y": -0.33104643,
+				"Z": 2.3312452
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -144.22736,
+				"Y": 9.488884,
+				"Z": 437.4958
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 8.485209,
+			"OtherCarId": -1,
+			"OtherDriver": {
+				"Guid": "",
+				"GuidsList": null,
+				"Name": "",
+				"Nation": "",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.96426576,
+				"Y": -0.26377523,
+				"Z": -1.2430801
+			},
+			"Type": "COLLISION_WITH_ENV",
+			"WorldPosition": {
+				"X": -140.0359,
+				"Y": 9.269851,
+				"Z": 438.2437
+			}
+		},
+		{
+			"CarId": 8,
+			"Driver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.49061668,
+			"OtherCarId": 1,
+			"OtherDriver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": 0.8671616,
+				"Y": -0.26368892,
+				"Z": 1.4969919
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -143.84271,
+				"Y": 9.422574,
+				"Z": 437.4544
+			}
+		},
+		{
+			"CarId": 1,
+			"Driver": {
+				"Guid": "76561198022717360",
+				"GuidsList": [
+					"76561198022717360"
+				],
+				"Name": "namelesssboy",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"ImpactSpeed": 0.2254504,
+			"OtherCarId": 8,
+			"OtherDriver": {
+				"Guid": "76561198055388877",
+				"GuidsList": [
+					"76561198055388877"
+				],
+				"Name": "L33 CR055L3Y",
+				"Nation": "PLA",
+				"Team": ""
+			},
+			"RelPosition": {
+				"X": -0.6401783,
+				"Y": -0.33818176,
+				"Z": 2.3590064
+			},
+			"Type": "COLLISION_WITH_CAR",
+			"WorldPosition": {
+				"X": -144.09935,
+				"Y": 9.4405985,
+				"Z": 437.45807
+			}
+		}
+	],
+	"Laps": [
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 66304,
+			"Restrictor": 0,
+			"Sectors": [
+				40290,
+				26014
+			],
+			"Timestamp": 889685,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 66938,
+			"Restrictor": 0,
+			"Sectors": [
+				41046,
+				25892
+			],
+			"Timestamp": 890317,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 68157,
+			"Restrictor": 0,
+			"Sectors": [
+				42038,
+				26119
+			],
+			"Timestamp": 891602,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 70399,
+			"Restrictor": 0,
+			"Sectors": [
+				44240,
+				26159
+			],
+			"Timestamp": 893779,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 70457,
+			"Restrictor": 0,
+			"Sectors": [
+				43165,
+				27292
+			],
+			"Timestamp": 893909,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 71391,
+			"Restrictor": 0,
+			"Sectors": [
+				44512,
+				26879
+			],
+			"Timestamp": 894780,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 73011,
+			"Restrictor": 0,
+			"Sectors": [
+				44957,
+				28054
+			],
+			"Timestamp": 896395,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 82204,
+			"Restrictor": 0,
+			"Sectors": [
+				44017,
+				38187
+			],
+			"Timestamp": 905579,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 82384,
+			"Restrictor": 0,
+			"Sectors": [
+				54857,
+				27527
+			],
+			"Timestamp": 905761,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 59391,
+			"Restrictor": 0,
+			"Sectors": [
+				33250,
+				26141
+			],
+			"Timestamp": 951001,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58339,
+			"Restrictor": 0,
+			"Sectors": [
+				32675,
+				25664
+			],
+			"Timestamp": 952120,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 60398,
+			"Restrictor": 0,
+			"Sectors": [
+				33876,
+				26522
+			],
+			"Timestamp": 955179,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 62661,
+			"Restrictor": 0,
+			"Sectors": [
+				35804,
+				26857
+			],
+			"Timestamp": 956570,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 68739,
+			"Restrictor": 0,
+			"Sectors": [
+				42922,
+				25817
+			],
+			"Timestamp": 958419,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 68114,
+			"Restrictor": 0,
+			"Sectors": [
+				41524,
+				26590
+			],
+			"Timestamp": 958428,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 62204,
+			"Restrictor": 0,
+			"Sectors": [
+				35574,
+				26630
+			],
+			"Timestamp": 967962,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 66416,
+			"Restrictor": 0,
+			"Sectors": [
+				38876,
+				27540
+			],
+			"Timestamp": 971993,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 77255,
+			"Restrictor": 0,
+			"Sectors": [
+				49148,
+				28107
+			],
+			"Timestamp": 973649,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58389,
+			"Restrictor": 0,
+			"Sectors": [
+				32757,
+				25632
+			],
+			"Timestamp": 1010505,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 60920,
+			"Restrictor": 0,
+			"Sectors": [
+				33741,
+				27179
+			],
+			"Timestamp": 1012415,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 60181,
+			"Restrictor": 0,
+			"Sectors": [
+				33649,
+				26532
+			],
+			"Timestamp": 1015357,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60037,
+			"Restrictor": 0,
+			"Sectors": [
+				34149,
+				25888
+			],
+			"Timestamp": 1018464,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 67184,
+			"Restrictor": 0,
+			"Sectors": [
+				40036,
+				27148
+			],
+			"Timestamp": 1023750,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61689,
+			"Restrictor": 0,
+			"Sectors": [
+				34076,
+				27613
+			],
+			"Timestamp": 1029650,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62476,
+			"Restrictor": 0,
+			"Sectors": [
+				34545,
+				27931
+			],
+			"Timestamp": 1036125,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 79092,
+			"Restrictor": 0,
+			"Sectors": [
+				42205,
+				36887
+			],
+			"Timestamp": 1037511,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 75827,
+			"Restrictor": 0,
+			"Sectors": [
+				48152,
+				27675
+			],
+			"Timestamp": 1047823,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58131,
+			"Restrictor": 0,
+			"Sectors": [
+				32575,
+				25556
+			],
+			"Timestamp": 1068635,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 59844,
+			"Restrictor": 0,
+			"Sectors": [
+				33456,
+				26388
+			],
+			"Timestamp": 1071756,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59307,
+			"Restrictor": 0,
+			"Sectors": [
+				33373,
+				25934
+			],
+			"Timestamp": 1077770,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 62633,
+			"Restrictor": 0,
+			"Sectors": [
+				35481,
+				27152
+			],
+			"Timestamp": 1086399,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 72865,
+			"Restrictor": 0,
+			"Sectors": [
+				33980,
+				38885
+			],
+			"Timestamp": 1088221,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61146,
+			"Restrictor": 0,
+			"Sectors": [
+				34096,
+				27050
+			],
+			"Timestamp": 1090795,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62051,
+			"Restrictor": 0,
+			"Sectors": [
+				34867,
+				27184
+			],
+			"Timestamp": 1098174,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 67756,
+			"Restrictor": 0,
+			"Sectors": [
+				41570,
+				26186
+			],
+			"Timestamp": 1105267,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58589,
+			"Restrictor": 0,
+			"Sectors": [
+				32336,
+				26253
+			],
+			"Timestamp": 1127222,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 80255,
+			"Restrictor": 0,
+			"Sectors": [
+				51473,
+				28782
+			],
+			"Timestamp": 1128068,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 59948,
+			"Restrictor": 0,
+			"Sectors": [
+				33741,
+				26207
+			],
+			"Timestamp": 1131702,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59769,
+			"Restrictor": 0,
+			"Sectors": [
+				33925,
+				25844
+			],
+			"Timestamp": 1137538,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 60752,
+			"Restrictor": 0,
+			"Sectors": [
+				34239,
+				26513
+			],
+			"Timestamp": 1147144,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 59887,
+			"Restrictor": 0,
+			"Sectors": [
+				33594,
+				26293
+			],
+			"Timestamp": 1148111,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 59975,
+			"Restrictor": 0,
+			"Sectors": [
+				33407,
+				26568
+			],
+			"Timestamp": 1150768,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62067,
+			"Restrictor": 0,
+			"Sectors": [
+				35368,
+				26699
+			],
+			"Timestamp": 1160241,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 66227,
+			"Restrictor": 0,
+			"Sectors": [
+				39705,
+				26522
+			],
+			"Timestamp": 1171493,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 63704,
+			"Restrictor": 0,
+			"Sectors": [
+				36209,
+				27495
+			],
+			"Timestamp": 1191770,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 60330,
+			"Restrictor": 0,
+			"Sectors": [
+				33955,
+				26375
+			],
+			"Timestamp": 1192032,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 66108,
+			"Restrictor": 0,
+			"Sectors": [
+				40484,
+				25624
+			],
+			"Timestamp": 1193329,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 60052,
+			"Restrictor": 0,
+			"Sectors": [
+				34096,
+				25956
+			],
+			"Timestamp": 1197589,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 60865,
+			"Restrictor": 0,
+			"Sectors": [
+				34428,
+				26437
+			],
+			"Timestamp": 1207995,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 60351,
+			"Restrictor": 0,
+			"Sectors": [
+				33549,
+				26802
+			],
+			"Timestamp": 1208461,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 59889,
+			"Restrictor": 0,
+			"Sectors": [
+				33276,
+				26613
+			],
+			"Timestamp": 1210657,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62783,
+			"Restrictor": 0,
+			"Sectors": [
+				35693,
+				27090
+			],
+			"Timestamp": 1223022,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 70333,
+			"Restrictor": 0,
+			"Sectors": [
+				34121,
+				36212
+			],
+			"Timestamp": 1241825,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 59993,
+			"Restrictor": 0,
+			"Sectors": [
+				33848,
+				26145
+			],
+			"Timestamp": 1252025,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59309,
+			"Restrictor": 0,
+			"Sectors": [
+				33628,
+				25681
+			],
+			"Timestamp": 1252635,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59450,
+			"Restrictor": 0,
+			"Sectors": [
+				33512,
+				25938
+			],
+			"Timestamp": 1257038,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 73663,
+			"Restrictor": 0,
+			"Sectors": [
+				44247,
+				29416
+			],
+			"Timestamp": 1265448,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 63773,
+			"Restrictor": 0,
+			"Sectors": [
+				36769,
+				27004
+			],
+			"Timestamp": 1274427,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 81109,
+			"Restrictor": 0,
+			"Sectors": [
+				53610,
+				27499
+			],
+			"Timestamp": 1289115,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 80739,
+			"Restrictor": 0,
+			"Sectors": [
+				53414,
+				27325
+			],
+			"Timestamp": 1289200,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 67871,
+			"Restrictor": 0,
+			"Sectors": [
+				34733,
+				33138
+			],
+			"Timestamp": 1290894,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 66335,
+			"Restrictor": 0,
+			"Sectors": [
+				39695,
+				26640
+			],
+			"Timestamp": 1308159,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58989,
+			"Restrictor": 0,
+			"Sectors": [
+				32519,
+				26470
+			],
+			"Timestamp": 1311624,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 60078,
+			"Restrictor": 0,
+			"Sectors": [
+				33140,
+				26938
+			],
+			"Timestamp": 1312104,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59412,
+			"Restrictor": 0,
+			"Sectors": [
+				33644,
+				25768
+			],
+			"Timestamp": 1316447,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 62789,
+			"Restrictor": 0,
+			"Sectors": [
+				35416,
+				27373
+			],
+			"Timestamp": 1328217,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 61338,
+			"Restrictor": 0,
+			"Sectors": [
+				34706,
+				26632
+			],
+			"Timestamp": 1335764,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 62625,
+			"Restrictor": 0,
+			"Sectors": [
+				34527,
+				28098
+			],
+			"Timestamp": 1353517,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 65120,
+			"Restrictor": 0,
+			"Sectors": [
+				35146,
+				29974
+			],
+			"Timestamp": 1354219,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 67067,
+			"Restrictor": 0,
+			"Sectors": [
+				33655,
+				33412
+			],
+			"Timestamp": 1356260,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 59026,
+			"Restrictor": 0,
+			"Sectors": [
+				33021,
+				26005
+			],
+			"Timestamp": 1370648,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 59463,
+			"Restrictor": 0,
+			"Sectors": [
+				33372,
+				26091
+			],
+			"Timestamp": 1375910,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 64493,
+			"Restrictor": 0,
+			"Sectors": [
+				32872,
+				31621
+			],
+			"Timestamp": 1376595,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 82415,
+			"Restrictor": 0,
+			"Sectors": [
+				48067,
+				34348
+			],
+			"Timestamp": 1390573,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 63488,
+			"Restrictor": 0,
+			"Sectors": [
+				35472,
+				28016
+			],
+			"Timestamp": 1391707,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 60043,
+			"Restrictor": 0,
+			"Sectors": [
+				33799,
+				26244
+			],
+			"Timestamp": 1395805,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 60446,
+			"Restrictor": 0,
+			"Sectors": [
+				33455,
+				26991
+			],
+			"Timestamp": 1416714,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 67842,
+			"Restrictor": 0,
+			"Sectors": [
+				34569,
+				33273
+			],
+			"Timestamp": 1421359,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 70184,
+			"Restrictor": 0,
+			"Sectors": [
+				34616,
+				35568
+			],
+			"Timestamp": 1424402,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"LapTime": 58960,
+			"Restrictor": 0,
+			"Sectors": [
+				32586,
+				26374
+			],
+			"Timestamp": 1429607,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"LapTime": 69263,
+			"Restrictor": 0,
+			"Sectors": [
+				35478,
+				33785
+			],
+			"Timestamp": 1445170,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"LapTime": 69464,
+			"Restrictor": 0,
+			"Sectors": [
+				35386,
+				34078
+			],
+			"Timestamp": 1446053,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"Cuts": 0,
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"LapTime": 61324,
+			"Restrictor": 0,
+			"Sectors": [
+				34630,
+				26694
+			],
+			"Timestamp": 1451897,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"Cuts": 0,
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"LapTime": 63516,
+			"Restrictor": 0,
+			"Sectors": [
+				36200,
+				27316
+			],
+			"Timestamp": 1455221,
+			"Tyre": "SM"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"Cuts": 0,
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"LapTime": 71141,
+			"Restrictor": 0,
+			"Sectors": [
+				43350,
+				27791
+			],
+			"Timestamp": 1466944,
+			"Tyre": "V70"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"LapTime": 61825,
+			"Restrictor": 0,
+			"Sectors": [
+				34807,
+				27018
+			],
+			"Timestamp": 1483183,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"LapTime": 67097,
+			"Restrictor": 0,
+			"Sectors": [
+				40840,
+				26257
+			],
+			"Timestamp": 1483806,
+			"Tyre": "V"
+		},
+		{
+			"BallastKG": 0,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"Cuts": 0,
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"LapTime": 60591,
+			"Restrictor": 0,
+			"Sectors": [
+				33856,
+				26735
+			],
+			"Timestamp": 1484994,
+			"Tyre": "V"
+		}
+	],
+	"Result": [
+		{
+			"BallastKG": 0,
+			"BestLap": 58131,
+			"CarId": 7,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198029578060",
+			"DriverName": "Joseph Elton",
+			"Restrictor": 0,
+			"TotalTime": 606222,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 59307,
+			"CarId": 1,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198022717360",
+			"DriverName": "namelesssboy",
+			"Restrictor": 0,
+			"TotalTime": 621787,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 59391,
+			"CarId": 14,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 622607,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 59889,
+			"CarId": 8,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198055388877",
+			"DriverName": "L33 CR055L3Y",
+			"Restrictor": 0,
+			"TotalTime": 643564,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61825,
+			"CarId": 19,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198020046073",
+			"DriverName": "Callum Jones",
+			"Restrictor": 0,
+			"TotalTime": 659795,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 59887,
+			"CarId": 15,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 660425,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 60591,
+			"CarId": 16,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 661541,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 61324,
+			"CarId": 2,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198023931313",
+			"DriverName": "Danny Wilson",
+			"Restrictor": 0,
+			"TotalTime": 628518,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 62789,
+			"CarId": 0,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198074322763",
+			"DriverName": "Seb",
+			"Restrictor": 0,
+			"TotalTime": 631842,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 9,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 10,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 5,
+			"CarModel": "a3dr_ferrari_512tr",
+			"DriverGuid": "76561198365646634",
+			"DriverName": "Cheezypoof",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 12,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 13,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 11,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 6,
+			"CarModel": "ks_porsche_911_carrera_rsr",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 4,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198437072463",
+			"DriverName": "rich p",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 17,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 18,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 3,
+			"CarModel": "a3dr_lambo_diablo_vt",
+			"DriverGuid": "76561198045844392",
+			"DriverName": "Spaceman9795",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 20,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		},
+		{
+			"BallastKG": 0,
+			"BestLap": 999999999,
+			"CarId": 21,
+			"CarModel": "ks_alfa_33_stradale",
+			"DriverGuid": "",
+			"DriverName": "",
+			"Restrictor": 0,
+			"TotalTime": 0,
+			"HasPenalty": false,
+			"PenaltyTime": 0,
+			"LapPenalty": 0,
+			"Disqualified": false
+		}
+	],
+	"TrackConfig": "layout_national",
+	"TrackName": "ks_red_bull_ring",
+	"Type": "RACE",
+	"Date": "2019-03-02T22:03:00Z",
+	"SessionFile": "2019_3_2_22_3_RACE",
+	"ChampionshipID": "b412c28d-b0d5-41e8-b551-7704e11fe35a"
+}

--- a/templates.go
+++ b/templates.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -182,6 +183,8 @@ func carList(cars interface{}) string {
 		split = strings.Split(cars, ";")
 	case []string:
 		split = cars
+	default:
+		panic("unknown type of cars: " + reflect.TypeOf(cars).String())
 	}
 
 	var out []string

--- a/templates.go
+++ b/templates.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -173,14 +174,23 @@ func dateFormat(t time.Time) string {
 	return t.Format("02/01/2006")
 }
 
-func carList(cars string) string {
-	var out []string
+func carList(cars interface{}) string {
+	var split []string
 
-	split := strings.Split(cars, ";")
+	switch cars := cars.(type) {
+	case string:
+		split = strings.Split(cars, ";")
+	case []string:
+		split = cars
+	}
+
+	var out []string
 
 	for _, s := range split {
 		out = append(out, prettifyName(s, true))
 	}
+
+	sort.Strings(out)
 
 	return strings.Join(out, ", ")
 }


### PR DESCRIPTION
* fixes issues with class/car switching within championship events causing duplicate entrants
* sorts the championship entrant tables and tidies them up, adding colour coding and classes
* empty drivers are filtered out of the entrant table and a 'n open slots' message is displayed instead
* car listings in championship pages now use the ValidCarIDs on the championship
* the open championship option now persists correctly
