### PR TITLE
Remove gray background and add some shadow to track outline

### DIFF
--- a/cmd/server-manager/static/css/style.css
+++ b/cmd/server-manager/static/css/style.css
@@ -363,7 +363,6 @@ footer a {
 #map {
     position: relative;
     border-radius: 0.25rem;
-    background-color: rgba(0,0,0,0.125);
 }
 
 #map.rotated {
@@ -373,8 +372,12 @@ footer a {
 
 #map.rotated .dot, #map.rotated .collision {
     transform: rotate(-90deg) translate(-50%, -50%);
-
     transform-origin: top left;
+}
+
+#map .img {
+    -webkit-filter: drop-shadow(0 0 2px #000);
+    filter: drop-shadow(0 0 2px #000);
 }
 
 .dot {


### PR DESCRIPTION
Just another little change to improve live map visualisation by removing the gray background and applying some `drop-shadow` to track outline. 

<img width="551" alt="Screen Shot 2019-05-15 at 21 20 11" src="https://user-images.githubusercontent.com/706729/57802959-7f1d5680-7757-11e9-91fa-7b9b71c8f239.png">
