### PR TITLE
pad millisecond values in msToTime to prevent misleading best lap times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Fixes:
 * Fixes a bug where the EntryList was limited to 18 entrants in Custom Races.
 * AutoFill entrants are now alphabetically sorted.
 * Laps which have Cuts > 0 are now excluded from "Best Lap" in Live Timings
+* Fixes misleading times in the Live Timings stored times table by adding leading zeroes to millisecond values under 100ms.
 
 v1.3.1
 ------

--- a/cmd/server-manager/javascript/manager.js
+++ b/cmd/server-manager/javascript/manager.js
@@ -1291,10 +1291,18 @@ class RaceSetup {
     }
 }
 
+function pad(num, size) {
+    let s = num + "";
+    while (s.length < size) {
+        s = "0" + s;
+    }
+    return s;
+}
+
 function msToTime(s) {
     let hours = (s / 3.6e6 | 0);
     let minutes = ((s % 3.6e6) / 6e4 | 0);
-    let seconds = ((s % 6e4) / 1000 | 0) + '.' + (s % 1000);
+    let seconds = ((s % 6e4) / 1000 | 0) + '.' + pad(s % 1000, 3);
 
     let output = '';
 


### PR DESCRIPTION
fixes #366