### PR TITLE
Don't use process.Kill() at all on Windows while killing processes

### DIFF
--- a/server_process_windows.go
+++ b/server_process_windows.go
@@ -7,20 +7,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-
-	"github.com/sirupsen/logrus"
 )
 
 const serverExecutablePath = "acServer.exe"
 
 func kill(process *os.Process) error {
-	err := process.Kill()
-
-	if err != nil {
-		logrus.WithError(err).Errorf("Initial attempt at killing windows process (process.Kill) failed")
-		return exec.Command("taskkill", "/T", "/PID", fmt.Sprintf("%d", process.Pid)).Run()
-	}
-
+	//apparently running Process.Kill() and THEN Taskill is a no-go
+	//using only taskkill /t /f works instead, so it's pointless to use Process.Kill() at all - Alberto
+	exec.Command("TASKKILL", "/T", "/F", "/PID", fmt.Sprintf("%d", process.Pid)).Run()
 	return nil
 }
 

--- a/server_process_windows.go
+++ b/server_process_windows.go
@@ -11,11 +11,8 @@ import (
 
 const serverExecutablePath = "acServer.exe"
 
-func kill(process *os.Process) error {
-	//apparently running Process.Kill() and THEN Taskill is a no-go
-	//using only taskkill /t /f works instead, so it's pointless to use Process.Kill() at all - Alberto
-	exec.Command("TASKKILL", "/T", "/F", "/PID", fmt.Sprintf("%d", process.Pid)).Run()
-	return nil
+func kill(process *os.Process) error {	
+	return exec.Command("TASKKILL", "/T", "/F", "/PID", fmt.Sprintf("%d", process.Pid)).Run()
 }
 
 func buildCommand(ctx context.Context, command string, args ...string) *exec.Cmd {


### PR DESCRIPTION
It only makes things messier and it can fail. A single taskkill command just works.