### PR TITLE
fixes popovers so they work with the new bootstrap update

### DIFF
--- a/cmd/server-manager/typescript/src/javascript/manager.js
+++ b/cmd/server-manager/typescript/src/javascript/manager.js
@@ -45,8 +45,10 @@ $(document).ready(function () {
     $("[data-toggle=popover]").each(function (i, obj) {
         $(this).popover({
             html: true,
+            sanitize: false,
             content: function () {
                 let id = $(this).attr('id');
+
                 return $('#popover-content-' + id).html();
             }
         });

--- a/cmd/server-manager/views/pages/championships/view.html
+++ b/cmd/server-manager/views/pages/championships/view.html
@@ -857,6 +857,7 @@
                                                  aria-labelledby="results-points-{{ $eventIndex}}-tab">
 
 
+                                                {{ $championshipHasTeamNames := $championship.HasTeamNames }}
 
                                                 <div class="table-responsive">
                                                     <table class="table table-bordered table-striped">
@@ -866,7 +867,9 @@
                                                             {{ end }}
                                                             <th>#</th>
                                                             <th>Name</th>
-                                                            <th>Team</th>
+                                                            {{ if $championshipHasTeamNames }}
+                                                                <th>Team</th>
+                                                            {{ end }}
                                                             <th>Car</th>
                                                             <th>Points</th>
                                                         </tr>
@@ -882,7 +885,9 @@
                                                                     {{ end }}
                                                                     <td>{{ add $pos 1 }}</td>
                                                                     <td>{{ driverName $standing.Car.Driver.Name }}</td>
-                                                                    <td>{{ $standing.Car.Driver.Team }}</td>
+                                                                    {{ if $championshipHasTeamNames }}
+                                                                        <td>{{ $standing.Car.Driver.Team }}</td>
+                                                                    {{ end }}
                                                                     <td>{{ prettify $standing.Car.Model true }}</td>
                                                                     <td>{{ $standing.Points }}</td>
                                                                 </tr>


### PR DESCRIPTION
removes team names from championship event points tables if nobody in the championship has a team name (fixes #417, fixes #418)