### PR TITLE
on client disconnect, if the driver has no loaded time, remove them from the connected drivers table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note, all of the new Car features work best when you have uploaded your cars to 
 Fixes:
 
 * Improved error handling when parsing config.yml, this should give an error with more detail rather than crashing.
+* Fixes a bug where drivers who connect but do not load were left in the Connected Drivers table in Live Timings.
 
 v1.3.3
 ------

--- a/cmd/server-manager/typescript/src/RaceControl.ts
+++ b/cmd/server-manager/typescript/src/RaceControl.ts
@@ -555,6 +555,17 @@ class LiveTimings implements WebsocketHandler {
         if (message.EventType === EventRaceControl) {
             this.populateConnectedDrivers();
             this.populateDisconnectedDrivers();
+        } else if (message.EventType === EventConnectionClosed) {
+            const closedConnection = message.Message as SessionCarInfo;
+
+            if (this.raceControl.status.ConnectedDrivers) {
+                const driver = this.raceControl.status.ConnectedDrivers.Drivers[closedConnection.DriverGUID];
+
+                if (driver.LoadedTime.toString() === "0001-01-01T00:00:00Z") {
+                    // a driver joined but never loaded. remove them from the connected drivers table.
+                    this.$connectedDriversTable.find("tr[data-guid='" + closedConnection.DriverGUID + "']").remove();
+                }
+            }
         }
     }
 

--- a/cmd/server-manager/typescript/src/RaceControl.ts
+++ b/cmd/server-manager/typescript/src/RaceControl.ts
@@ -565,7 +565,7 @@ class LiveTimings implements WebsocketHandler {
             if (this.raceControl.status.ConnectedDrivers) {
                 const driver = this.raceControl.status.ConnectedDrivers.Drivers[closedConnection.DriverGUID];
 
-                if (driver.LoadedTime.toString() === "0001-01-01T00:00:00Z") {
+                if (driver && driver.LoadedTime.toString() === "0001-01-01T00:00:00Z") {
                     // a driver joined but never loaded. remove them from the connected drivers table.
                     this.$connectedDriversTable.find("tr[data-guid='" + closedConnection.DriverGUID + "']").remove();
                 }

--- a/content_manager_wrapper.go
+++ b/content_manager_wrapper.go
@@ -177,6 +177,10 @@ func (cmw *ContentManagerWrapper) Start(process ServerProcess, servePort int, se
 }
 
 func (cmw *ContentManagerWrapper) Stop() {
+	if cmw.srv == nil {
+		return
+	}
+
 	logrus.Infof("Shutting down content manager wrapper server")
 	err := cmw.srv.Shutdown(context.Background())
 

--- a/server_process.go
+++ b/server_process.go
@@ -311,6 +311,10 @@ func (as *AssettoServerProcess) IsRunning() bool {
 }
 
 func (as *AssettoServerProcess) Event() RaceEvent {
+	if as.event == nil {
+		return normalEvent{}
+	}
+
 	return as.event
 }
 
@@ -353,7 +357,9 @@ func (as *AssettoServerProcess) Stop() error {
 		loopNum++
 	}
 
-	as.contentManagerWrapper.Stop()
+	if as.serverConfig.GlobalServerConfig.EnableContentManagerWrapper == 1 && as.serverConfig.GlobalServerConfig.ContentManagerWrapperPort > 0 {
+		as.contentManagerWrapper.Stop()
+	}
 
 	as.cmd = nil
 	go func() {


### PR DESCRIPTION
fixes #428 