### PR TITLE
open championships: swap the assigned entrant with the free entrant slot when adding entrants to the Championship entrylist 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Fixes:
 * MOTD text will now be automatically wrapped to prevent large horizontal messages on join.
 * Fixes a bug where drivers who connect but do not load were left in the Connected Drivers table in Live Timings.
 * Live Timings will now reconnect automatically if your connection drops.
+* Fixes an issue where Open Championship EntryLists would not be correctly preserved when assigning car slots to pre-existing Entrants. 
 
 v1.3.3
 ------

--- a/championships_test.go
+++ b/championships_test.go
@@ -389,4 +389,53 @@ func TestChampionship_AddEntrantFromSession(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Entrant joined and was placed in a different grid slot. Their extra properties (especially InternalUUID) should persist (#441)", func(t *testing.T) {
+		potentialEntrant := &SessionCar{
+			Driver: SessionDriver{
+				GUID:      "78987656782716273",
+				GuidsList: []string{"78987656782716273"},
+				Name:      "Driver 1",
+				Team:      "Team Name",
+			},
+			Model: "ferrari_fxx_k",
+			Skin:  "skin_01",
+		}
+
+		class := NewChampionshipClass("FXX K")
+		e := NewEntrant()
+		e.Model = "ferrari_fxx_k"
+
+		class.Entrants.Add(e)
+
+		e2 := NewEntrant()
+		e2.Model = "ferrari_fxx_k"
+		e2.GUID = "78987656782716273"
+
+		class.Entrants.Add(e2)
+
+		champ := &Championship{}
+		champ.AddClass(class)
+
+		emptySlotUUID := e.InternalUUID
+		currentInternalUUID := e2.InternalUUID
+
+		_, _, err := champ.AddEntrantFromSession(potentialEntrant)
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		for _, entrant := range class.Entrants {
+			if entrant.GUID == "78987656782716273" && entrant.InternalUUID != currentInternalUUID {
+				t.Log("Expected entrant guid to have carried over, it did not")
+				t.Fail()
+			}
+
+			if entrant.GUID == "" && entrant.InternalUUID != emptySlotUUID {
+				t.Log("Expected entrant guid swap")
+				t.Fail()
+			}
+		}
+	})
 }

--- a/entrylist_ini.go
+++ b/entrylist_ini.go
@@ -175,3 +175,14 @@ func (e *Entrant) OverwriteProperties(other *Entrant) {
 	e.Skin = other.Skin
 	e.PitBox = other.PitBox
 }
+
+func (e *Entrant) SwapProperties(other *Entrant) {
+	e.Model, other.Model = other.Model, e.Model
+	e.Skin, other.Skin = other.Skin, e.Skin
+	e.Team, other.Team = other.Team, e.Team
+	e.InternalUUID, other.InternalUUID = other.InternalUUID, e.InternalUUID
+	e.FixedSetup, other.FixedSetup = other.FixedSetup, e.FixedSetup
+	e.Restrictor, other.Restrictor = other.Restrictor, e.Restrictor
+	e.Ballast, other.Ballast = other.Ballast, e.Ballast
+	e.PitBox, other.PitBox = other.PitBox, e.PitBox
+}


### PR DESCRIPTION
prevents mismatching entrant data when assigning slots

fixes #441 