### PR TITLE
cj123/assetto-server-manager#271: Allow users to set LOCKED_ENTRY_LIST and PICKUP_MODE separately as they want

### DIFF
--- a/cmd/server-manager/views/pages/custom-race/new.html
+++ b/cmd/server-manager/views/pages/custom-race/new.html
@@ -561,6 +561,27 @@
                     <div class="hidden-booking-enabled">
 
                         <div class="form-group row">
+                            <label for="PickupModeEnabled" class="col-sm-3 col-form-label">Pickup Mode</label>
+
+
+                            <div class="col-sm-9">
+                                <input type="checkbox"
+                                       id="PickupModeEnabled"
+                                       name="PickupModeEnabled"
+                                       value="{{ $f.PickupModeEnabled }}"
+
+                                        {{ if eq $f.PickupModeEnabled 1 }}
+                                            checked="checked"
+                                        {{ end }}
+                                >
+
+                                <br>
+
+                                <small>Only players already included in the entry list can join the server. This setting uses the PickupModeEnabled option in the Assetto Corsa configuration file. Note, sessions with Loop Mode ON will require players to rejoin the server when the server loops.</small>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
                             <label for="LockedEntryList" class="col-sm-3 col-form-label">Locked Entry List</label>
 
 
@@ -568,16 +589,16 @@
                                 <input type="checkbox"
                                        id="LockedEntryList"
                                        name="LockedEntryList"
-                                       value="{{ $f.PickupModeEnabled }}"
+                                       value="{{ $f.LockedEntryList }}"
 
-                                        {{ if eq $f.PickupModeEnabled 0 }}
+                                        {{ if eq $f.LockedEntryList 1 }}
                                             checked="checked"
                                         {{ end }}
                                 >
 
                                 <br>
 
-                                <small>Only players already included in the entry list can join the server. This setting uses the PickupModeEnabled option in the Assetto Corsa configuration file. Note, when Locked Entry List is ON, sessions with Loop Mode ON will require players to rejoin the server when the server loops.</small>
+                                <small>Only players already included in the entry list can join the server</small>
                             </div>
                         </div>
 

--- a/cmd/server-manager/views/pages/custom-race/new.html
+++ b/cmd/server-manager/views/pages/custom-race/new.html
@@ -577,7 +577,7 @@
 
                                 <br>
 
-                                <small>Only players already included in the entry list can join the server. This setting uses the PickupModeEnabled option in the Assetto Corsa configuration file. Note, sessions with Loop Mode ON will require players to rejoin the server when the server loops.</small>
+                                <small>if 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list only a circuit under TRACK and you need to list a least one car in the entry_list</small>
                             </div>
                         </div>
 

--- a/cmd/server-manager/views/pages/custom-race/new.html
+++ b/cmd/server-manager/views/pages/custom-race/new.html
@@ -577,7 +577,7 @@
 
                                 <br>
 
-                                <small>If 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list a least one car in the entry list</small>
+                                <small>If 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list a least one car in the entry list. Note, when Pickup Mode is OFF, sessions with Loop Mode ON will require players to rejoin the server when the server loops.</small>
                             </div>
                         </div>
 

--- a/cmd/server-manager/views/pages/custom-race/new.html
+++ b/cmd/server-manager/views/pages/custom-race/new.html
@@ -577,7 +577,7 @@
 
                                 <br>
 
-                                <small>if 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list only a circuit under TRACK and you need to list a least one car in the entry_list</small>
+                                <small>If 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list a least one car in the entry list</small>
                             </div>
                         </div>
 

--- a/config_ini.go
+++ b/config_ini.go
@@ -210,7 +210,8 @@ type CurrentRaceConfig struct {
 	MaxContactsPerKilometer   int    `ini:"MAX_CONTACTS_PER_KM" help:"Maximum number times you can make contact with another car in 1 kilometer."`
 	ResultScreenTime          int    `ini:"RESULT_SCREEN_TIME" help:"Seconds of result screen between racing sessions"`
 
-	PickupModeEnabled int `ini:"PICKUP_MODE_ENABLED" help:"if 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list only a circuit under TRACK and you need to list a least one car in the entry_list"`
+	PickupModeEnabled int `ini:"PICKUP_MODE_ENABLED" input:"checkbox" help:"if 0 the server start in booking mode (do not use it). Warning: in pickup mode you have to list only a circuit under TRACK and you need to list a least one car in the entry_list"`
+	LockedEntryList int `ini:"LOCKED_ENTRY_LIST" input:"checkbox" help:"Only players already included in the entry list can join the server"`
 	LoopMode          int `ini:"LOOP_MODE" input:"checkbox" help:"the server restarts from the first track, to disable this set it to 0"`
 
 	MaxClients   int `ini:"MAX_CLIENTS" help:"max number of clients (must be <= track's number of pits)"`
@@ -231,8 +232,6 @@ type CurrentRaceConfig struct {
 	Sessions Sessions                  `ini:"-"`
 	Weather  map[string]*WeatherConfig `ini:"-"`
 
-	// Deprecated: Use PickupModeEnabled instead. (PickupModeEnabled == !LockedEntryList)
-	LockedEntryList int `ini:"LOCKED_ENTRY_LIST" input:"checkbox" help:"Only players already included in the entry list can join the server"`
 }
 
 type Sessions map[SessionType]SessionConfig

--- a/race_manager.go
+++ b/race_manager.go
@@ -425,17 +425,12 @@ func (rm *RaceManager) BuildCustomRaceFromForm(r *http.Request) (*CurrentRaceCon
 
 	gasPenaltyDisabled := formValueAsInt(r.FormValue("RaceGasPenaltyDisabled"))
 	lockedEntryList := formValueAsInt(r.FormValue("LockedEntryList"))
+	pickupModeEnabled := formValueAsInt(r.FormValue("PickupModeEnabled"))
 
 	if gasPenaltyDisabled == 0 {
 		gasPenaltyDisabled = 1
 	} else {
 		gasPenaltyDisabled = 0
-	}
-
-	if lockedEntryList == 0 {
-		lockedEntryList = 1
-	} else {
-		lockedEntryList = 0
 	}
 
 	trackLayout := r.FormValue("TrackLayout")
@@ -481,7 +476,8 @@ func (rm *RaceManager) BuildCustomRaceFromForm(r *http.Request) (*CurrentRaceCon
 		},
 
 		// rules
-		PickupModeEnabled:         lockedEntryList,
+		PickupModeEnabled:         pickupModeEnabled,
+		LockedEntryList:           lockedEntryList,
 		RacePitWindowStart:        formValueAsInt(r.FormValue("RacePitWindowStart")),
 		RacePitWindowEnd:          formValueAsInt(r.FormValue("RacePitWindowEnd")),
 		ReversedGridRacePositions: formValueAsInt(r.FormValue("ReversedGridRacePositions")),


### PR DESCRIPTION
The issue comes directly from Kunos, there's not much we can do. Kunos is not dropping any further AC updates anyway.

We pretty much confirmed both options have their own different problems, at this point letting the user decide which setting to go for is the best option, IMO.