### PR TITLE
Check for symlink in car setups

### DIFF
--- a/content_setups.go
+++ b/content_setups.go
@@ -32,7 +32,14 @@ func ListAllSetups() (CarSetups, error) {
 
 	setups := make(CarSetups)
 
-	err := filepath.Walk(setupDirectory, func(path string, file os.FileInfo, _ error) error {
+	// multi server installs may use symbolic links for setups folder, which filepath.Walk will ignore
+	setupDirectory, err := filepath.EvalSymlinks(setupDirectory)
+
+	if err != nil {
+		setupDirectory = filepath.Join(ServerInstallPath, "setups")
+	}
+
+	err = filepath.Walk(setupDirectory, func(path string, file os.FileInfo, _ error) error {
 		if file.IsDir() || filepath.Ext(file.Name()) != ".ini" {
 			return nil
 		}


### PR DESCRIPTION
I have three ASM servers, which share a common setup folder using symlinks from each server's assetto folder ...

shared/setups
server1/assetto
server1/assetto/setups => shared/setups
server2/assetto
server2/assetto/setups => shared/setups
server3/assetto
server3/assetto/setups => shared/setups

Ran into an issue with the car setups code, which uses filepath.Walk() on the setups path ... and filepath.Walk() doesn't traverse symlinks.  So no setups show for any cars, although they can be uploaded.

The fix seems to be to de-reference the setup path with EvalSymlinks() when reading the setups, which returns the path unchanged if it's not a symlink, or the target path if it is.

Tested on Ubuntu and Windows 10 (soft links), with and without setup path being a link.

