### PR TITLE
Create empty skins folder if it doesn't exist

### DIFF
--- a/content_cars.go
+++ b/content_cars.go
@@ -272,7 +272,15 @@ func (cm *CarManager) LoadCar(name string, tyres Tyres) (*Car, error) {
 			skins = append(skins, skinFile.Name())
 		}
 	} else {
-		logrus.WithError(err).Warnf("Could not load skins for car: %s", name)
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(filepath.Join(carDirectory, "skins"), 0755); err != nil {
+				logrus.WithError(err).Warnf("Could not create skins directory for car: %s", name)
+			} else {
+				logrus.Infof("Created empty skins directory for car: %s", name)
+			}
+		} else {
+			logrus.WithError(err).Warnf("Could not load skins for car: %s", name)
+		}
 	}
 
 	carDetails := CarDetails{}


### PR DESCRIPTION
The content folder on my league server has no skins folders for cars, as they haven't been needed in the past.  So I get hundreds of basically spurious log msgs warning me about not being able to load skins, which keep repeating.

This PR simply creates an empty skins folder if one doesn't exist, cutting down on constant naggy warnings.