### PR TITLE
Couple of sanity checks on setup files

### DIFF
--- a/content_setups.go
+++ b/content_setups.go
@@ -44,6 +44,11 @@ func ListAllSetups() (CarSetups, error) {
 			return nil
 		}
 
+		// corner case of stray ini files winding up in the top level of the folder
+		if filepath.ToSlash(filepath.Dir(path)) == filepath.ToSlash(setupDirectory) {
+			return nil
+		}
+
 		// read the setup file to get the car name
 		name, err := getCarNameFromSetup(path)
 

--- a/entrylist_ini.go
+++ b/entrylist_ini.go
@@ -2,6 +2,7 @@ package servermanager
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,6 +17,17 @@ type EntryList map[string]*Entrant
 
 // Write the EntryList to the server location
 func (e EntryList) Write() error {
+	setupDirectory := filepath.Join(ServerInstallPath, "setups")
+
+	// belt and braces check to make sure setup file exists
+	for _, entrant := range e.AsSlice() {
+		if entrant.FixedSetup != "" {
+			if _, err := os.Stat(filepath.Join(setupDirectory, entrant.FixedSetup)); os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+
 	for i, entrant := range e.AsSlice() {
 		entrant.PitBox = i
 	}


### PR DESCRIPTION
This PR adds a couple of checks so that if there are stray setup files at the root of the setups folder, it doesn't potentially break things.  Not likely to happen, but in my specific use case I share a setup folder with some other (non server-manager) provisioning, which has setup files at the root.  This confused SM, and led to a situation where a race would fail silently.

These two checks should a) prevent those from being shown in the race setup in the first place, and b) prevent problems if a previously uploaded setup was deleted, but still in use in a race config.