### PR TITLE
Avoid printing track's downloadURL if empty

### DIFF
--- a/content_manager_wrapper.go
+++ b/content_manager_wrapper.go
@@ -170,7 +170,7 @@ func (cmw *ContentManagerWrapper) setDescriptionText(event RaceEvent) error {
 
 		if err != nil {
 			logrus.WithError(err).Warnf("Could not load meta data for: %s, skipping attaching download URL to Content Manager Wrapper", cmw.serverConfig.CurrentRaceConfig.Track)
-		} else {
+		} else if track.MetaData.DownloadURL != "" {
 			text += fmt.Sprintf("\n* %s Download: %s", track.Name, track.MetaData.DownloadURL)
 		}
 	}


### PR DESCRIPTION
Quick fix to avoid showing non-useful string in Content Manager.

Steps followed:
- Add a download URL in a track's metadata and save.
- Remove the previously added download URL.
- Start a session.
- Content Manager shows track's download string without content.