### PR TITLE
results improvements: car swapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Fixes:
 
 * Setting the ballast on an entrant to a larger value than the Max Ballast option no longer stops the server from starting.
 * Results pages now correctly display statistics per car - so if you're switching cars in a session you can see accurate reports for that car.
+* Penalties are now applied per driver and car, rather than just per driver.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 Fixes:
 
 * Setting the ballast on an entrant to a larger value than the Max Ballast option no longer stops the server from starting.
+* Results pages now correctly display statistics per car - so if you're switching cars in a session you can see accurate reports for that car.
 
 ---
 

--- a/championships.go
+++ b/championships.go
@@ -969,7 +969,7 @@ func (c *ChampionshipClass) standings(events []*ChampionshipEvent, givePoints fu
 				if sessionType == SessionTypeRace || sessionType == SessionTypeSecondRace {
 					givePoints(event, driver.DriverGUID, float64(points.CollisionWithDriver*session.Results.GetCrashesOfType(driver.DriverGUID, "COLLISION_WITH_CAR"))*pointsMultiplier*-1, PointsCollisionWithCar)
 					givePoints(event, driver.DriverGUID, float64(points.CollisionWithEnv*session.Results.GetCrashesOfType(driver.DriverGUID, "COLLISION_WITH_ENV"))*pointsMultiplier*-1, PointsCollisionWithEnvironment)
-					givePoints(event, driver.DriverGUID, float64(points.CutTrack*session.Results.GetCuts(driver.DriverGUID))*pointsMultiplier*-1, PointsCutTrack)
+					givePoints(event, driver.DriverGUID, float64(points.CutTrack*session.Results.GetCuts(driver.DriverGUID, driver.CarModel))*pointsMultiplier*-1, PointsCutTrack)
 				}
 			}
 		}

--- a/cmd/server-manager/views/pages/results/result.html
+++ b/cmd/server-manager/views/pages/results/result.html
@@ -1,13 +1,14 @@
 {{/* gotype: github.com/cj123/assetto-server-manager.resultsViewTemplateVars */}}
 
-{{ define "title" }}Results{{ end }}
+{{ define "title" }}
+    {{ prettify $.Result.TrackName false }} {{ with $.Result.TrackConfig }} - {{ prettify . true }} {{ end }} Results ({{ $.Result.GetDate }})
+{{ end }}
 
 {{ define "content" }}
 <div class="results">
     {{ $sessionResults := .Result }}
     {{ $account := .Account }}
     {{ $useMPH := .UseMPH }}
-
 
     <h1 class="text-center">{{ prettify $sessionResults.TrackName false }} {{ with $sessionResults.TrackConfig }} - {{ prettify . true }} {{ end }}</h1>
     <div class="text-center">{{ $sessionResults.GetDate }}</div>
@@ -96,10 +97,10 @@
                                             {{ range $pos, $event := $sessionResults.Events }}
                                                 <tr {{ if eq $account.GUID $event.Driver.GUID }}style="font-weight: bold"{{ end }}>
                                                     <td>{{ add $pos 1 }}</td>
-                                                    <td class="driver-link" data-href="#{{ $event.Driver.GUID }}">{{ driverName $event.Driver.Name }}</td>
-                                                    <td class="driver-link" data-href="#{{ $event.OtherDriver.GUID }}">{{ driverName $event.OtherDriver.Name }}</td>
+                                                    <td class="driver-link" data-href="#{{ $event.Driver.GUID }}-{{ $event.CarID }}">{{ driverName $event.Driver.Name }}</td>
+                                                    <td class="driver-link" data-href="#{{ $event.OtherDriver.GUID }}-{{ $event.OtherCarID }}">{{ driverName $event.OtherDriver.Name }}</td>
                                                     <td>
-                                                        {{ if eq $event.Type "COLLISION_WITH_ENV"}}
+                                                        {{ if eq $event.Type "COLLISION_WITH_ENV" }}
                                                             Collision with environment
                                                         {{ else }}
                                                             Collision with car
@@ -176,7 +177,7 @@
     <div class="clearfix"></div>
 
     {{ range $i, $sessionResult := .Result.Result }}
-        <a name={{ $sessionResult.DriverGUID }}></a>
+        <a name="{{ $sessionResult.DriverGUID }}-{{ $sessionResult.CarID }}"></a>
         <div class="card mt-3 border-secondary">
             <div class="card-header {{ if eq $account.GUID $sessionResult.DriverGUID }}bg-success text-white{{ end }}">
                 <strong>{{ add $i 1 }}{{ ordinal (add $i 1) }} {{ driverName $sessionResult.DriverName }}
@@ -205,15 +206,15 @@
                                 </tr>
 
                                 {{ $lapCount := 0}}
-                                {{ $averageLapTime := $sessionResults.GetAverageLapTime $sessionResult.DriverGUID }}
+                                {{ $averageLapTime := $sessionResults.GetAverageLapTime $sessionResult.DriverGUID $sessionResult.CarModel }}
 
                                 {{ range $y, $sessionLap := $sessionResults.Laps }}
-                                    {{ if eq $sessionLap.DriverGUID $sessionResult.DriverGUID }}
+                                    {{ if and (eq $sessionLap.DriverGUID $sessionResult.DriverGUID) (eq $sessionLap.CarModel $sessionResult.CarModel) }}
                                         {{ $lapCount = add $lapCount 1 }}
                                         <tr>
                                             <td>{{ $lapCount }}</td>
                                             {{ if eq "RACE" $sessionResults.Type.OriginalString }}
-                                                <td>{{ $sessionResults.GetPosForLap $sessionResult.DriverGUID $lapCount }}</td>
+                                                <td>{{ $sessionResults.GetPosForLap $sessionResult.DriverGUID $sessionResult.CarModel $lapCount }}</td>
                                             {{ end }}
                                             <td>
                                                 {{ formatDuration $sessionLap.GetLapTime true }}
@@ -224,7 +225,7 @@
                                                     </div>
                                                 {{ end }}
 
-                                                {{ if $sessionResults.IsDriversFastestLap $sessionLap.DriverGUID $sessionLap.LapTime $sessionLap.Cuts }}
+                                                {{ if $sessionResults.IsDriversFastestLap $sessionLap.DriverGUID $sessionLap.CarModel $sessionLap.LapTime $sessionLap.Cuts }}
                                                     <div class="float-right mr-1">
                                                         <span data-toggle="tooltip" title="Driver's Fastest Lap" class="badge badge-success">L</span>
                                                     </div>
@@ -247,7 +248,7 @@
                                                         </div>
                                                     {{ end }}
 
-                                                    {{ if $sessionResults.IsDriversFastestSector $sessionLap.DriverGUID $x (index $sessionLap.Sectors $x) $sessionLap.Cuts }}
+                                                    {{ if $sessionResults.IsDriversFastestSector $sessionLap.DriverGUID $sessionLap.CarModel $x (index $sessionLap.Sectors $x) $sessionLap.Cuts }}
                                                         <div class="float-right mr-1">
                                                             <span data-toggle="tooltip" title="Driver's Fastest Sector" class="badge badge-success">S</span>
                                                         </div>

--- a/cmd/server-manager/views/partials/results/session-overall.html
+++ b/cmd/server-manager/views/partials/results/session-overall.html
@@ -75,11 +75,11 @@
                                 <td>
                                     <button type="button" class="btn btn-warning btn-sm" data-placement="left"
                                        data-toggle="popover" title="Penalty Details" data-html="true"
-                                        id="result-{{ $result.DriverGUID }}-{{ $sessionResults.SessionFile }}"
+                                        id="result-{{ $result.DriverGUID }}-{{ $result.CarModel }}-{{ $sessionResults.SessionFile }}"
                                         >Penalties</button>
 
-                                    <div id="popover-content-result-{{ $result.DriverGUID }}-{{ $sessionResults.SessionFile }}" style="display: none;">
-                                        <form action='/penalties/{{ $sessionResults.SessionFile }}/{{ $result.DriverGUID }}' method='POST'>
+                                    <div id="popover-content-result-{{ $result.DriverGUID }}-{{ $result.CarModel }}-{{ $sessionResults.SessionFile }}" style="display: none;">
+                                        <form action='/penalties/{{ $sessionResults.SessionFile }}/{{ $result.DriverGUID }}?model={{ $result.CarModel }}' method='POST'>
                                             <div class='form-group'>
                                                 <label for='time-penalty'>Time Penalty (seconds)</label>
                                                 <input type='number' class='form-control' name='time-penalty' id='time-penalty' placeholder='0' step='0.1'>
@@ -167,11 +167,11 @@
                                 <td>
                                     <button type="button" class="btn btn-warning btn-sm" data-placement="left"
                                             data-toggle="popover" title="Penalty Details" data-html="true"
-                                            id="result-{{ $result.DriverGUID }}-{{ $sessionResults.SessionFile }}"
+                                            id="result-{{ $result.DriverGUID }}-{{ $result.CarModel }}-{{ $sessionResults.SessionFile }}"
                                     >Penalties</button>
 
-                                    <div id="popover-content-result-{{ $result.DriverGUID }}-{{ $sessionResults.SessionFile }}" style="display: none;">
-                                        <form action='/penalties/{{ $sessionResults.SessionFile }}/{{ $result.DriverGUID }}' method='POST'>
+                                    <div id="popover-content-result-{{ $result.DriverGUID }}-{{ $result.CarModel }}-{{ $sessionResults.SessionFile }}" style="display: none;">
+                                        <form action='/penalties/{{ $sessionResults.SessionFile }}/{{ $result.DriverGUID }}?model={{ $result.CarModel }}' method='POST'>
                                             <div class='form-group'>
                                                 <label for='time-penalty'>Time Penalty (seconds)</label>
                                                 <input type='number' class='form-control' name='time-penalty' id='time-penalty' placeholder='0' step='0.1'>
@@ -259,11 +259,11 @@
                                 <td>
                                     <button type="button" class="btn btn-warning btn-sm" data-placement="left"
                                             data-toggle="popover" title="Penalty Details" data-html="true"
-                                            id="result-{{ $result.DriverGUID }}-{{ $sessionResults.SessionFile }}"
+                                            id="result-{{ $result.DriverGUID }}-{{ $result.CarModel }}-{{ $sessionResults.SessionFile }}"
                                     >Penalties</button>
 
-                                    <div id="popover-content-result-{{ $result.DriverGUID }}-{{ $sessionResults.SessionFile }}" style="display: none;">
-                                        <form action='/penalties/{{ $sessionResults.SessionFile }}/{{ $result.DriverGUID }}' method='POST'>
+                                    <div id="popover-content-result-{{ $result.DriverGUID }}-{{ $result.CarModel }}-{{ $sessionResults.SessionFile }}" style="display: none;">
+                                        <form action='/penalties/{{ $sessionResults.SessionFile }}/{{ $result.DriverGUID }}?model={{ $result.CarModel }}' method='POST'>
                                             <div class='form-group'>
                                                 <label for='time-penalty'>Time Penalty (seconds)</label>
                                                 <input type='number' class='form-control' name='time-penalty' id='time-penalty' placeholder='0' step='0.1'>

--- a/cmd/server-manager/views/partials/results/session-overall.html
+++ b/cmd/server-manager/views/partials/results/session-overall.html
@@ -29,7 +29,7 @@
                     {{ with $result.DriverGUID }}
                         <tr {{ if eq $account.GUID $result.DriverGUID }}style="font-weight: bold"{{ end }}>
                             <td>{{ add $pos 1 }}</td>
-                            <td class="driver-link" data-href="#{{ $result.DriverGUID }}">{{ driverName $result.DriverName }}
+                            <td class="driver-link" data-href="#{{ $result.DriverGUID }}-{{ $result.CarID }}">{{ driverName $result.DriverName }}
                                 {{ if $result.HasPenalty }} <span class="badge badge-danger">Time Penalty: {{ $result.PenaltyTime }}</span> {{ end }}
                                 {{ if $result.Disqualified }} <span class="badge badge-danger">Disqualified</span> {{ end }}</td>
 
@@ -37,17 +37,17 @@
                                 <td>{{ $sessionResults.GetTeamName $result.DriverGUID }}</td>
                             {{ end }}
                             <td>{{ prettify $result.CarModel true }}</td>
-                            <td>{{ formatDuration ($sessionResults.GetTime $result.TotalTime $result.DriverGUID true) false }}</td>
-                            <td>{{ $sessionResults.GetNumLaps $result.DriverGUID }} laps /
-                                {{ $sessionResults.GetCuts $result.DriverGUID }} cuts</td>
+                            <td>{{ formatDuration ($sessionResults.GetTime $result.TotalTime $result.DriverGUID $result.CarModel true) false }}</td>
+                            <td>{{ $sessionResults.GetNumLaps $result.DriverGUID $result.CarModel }} laps /
+                                {{ $sessionResults.GetCuts $result.DriverGUID $result.CarModel }} cuts</td>
                             <td>
-                                {{ $bestLap := $sessionResults.GetTime $result.BestLap $result.DriverGUID false }}
+                                {{ $bestLap := $sessionResults.GetTime $result.BestLap $result.DriverGUID $result.CarModel false }}
                                 {{  formatDuration $bestLap true }}<br>
                                 {{ if gt $bestLap 0 }}
                                     <small class="text-muted">Tyre: {{ $result.BestLapTyre $sessionResults }}</small>
                                 {{ end }}
                             </td>
-                            <td>{{ formatDuration ($sessionResults.GetAverageLapTime $result.DriverGUID) true }}</td>
+                            <td>{{ formatDuration ($sessionResults.GetAverageLapTime $result.DriverGUID $result.CarModel) true }}</td>
                             <td>
                                 {{ $hasHandicap := false }}
 
@@ -124,7 +124,7 @@
                     {{ with $result.DriverGUID }}
                         <tr {{ if eq $account.GUID $result.DriverGUID }}style="font-weight: bold"{{ end }}>
                             <td>{{ add $pos 1 }}</td>
-                            <td class="driver-link" data-href="#{{ $result.DriverGUID }}">{{ driverName $result.DriverName }}
+                            <td class="driver-link" data-href="#{{ $result.DriverGUID }}-{{ $result.CarID }}">{{ driverName $result.DriverName }}
                                 {{ if $result.HasPenalty }} <span class="badge badge-danger">Time Penalty: {{ $result.PenaltyTime }}</span> {{ end }}
                                 {{ if $result.Disqualified }} <span class="badge badge-danger">Disqualified</span> {{ end }}</td>
                             {{ if $driversHaveTeams }}
@@ -132,15 +132,15 @@
                             {{ end }}
                             <td>{{ prettify $result.CarModel true }}</td>
                             <td>
-                                {{ $bestLap := $sessionResults.GetTime $result.BestLap $result.DriverGUID true }}
+                                {{ $bestLap := $sessionResults.GetTime $result.BestLap $result.DriverGUID $result.CarModel true }}
                                 {{ formatDuration $bestLap true }}<br>
                                 {{ if gt $bestLap 0 }}
                                     <small class="text-muted">Tyre: {{ $result.BestLapTyre $sessionResults }}</small>
                                 {{ end }}
                             </td>
-                            <td>{{ formatDuration ($sessionResults.GetAverageLapTime $result.DriverGUID) true }}</td>
-                            <td>{{ $sessionResults.GetNumLaps $result.DriverGUID }} laps /
-                                {{ $sessionResults.GetCuts $result.DriverGUID }} cuts</td>
+                            <td>{{ formatDuration ($sessionResults.GetAverageLapTime $result.DriverGUID $result.CarModel) true }}</td>
+                            <td>{{ $sessionResults.GetNumLaps $result.DriverGUID $result.CarModel }} laps /
+                                {{ $sessionResults.GetCuts $result.DriverGUID $result.CarModel }} cuts</td>
                             <td>
                                 {{ $hasHandicap := false }}
 
@@ -216,7 +216,7 @@
                     {{ with $result.DriverGUID }}
                         <tr {{ if eq $account.GUID $result.DriverGUID }}style="font-weight: bold"{{ end }}>
                             <td>{{ add $pos 1 }}</td>
-                            <td class="driver-link" data-href="#{{ $result.DriverGUID }}">{{ driverName $result.DriverName }}
+                            <td class="driver-link" data-href="#{{ $result.DriverGUID }}-{{ $result.CarID }}">{{ driverName $result.DriverName }}
                                 {{ if $result.HasPenalty }} <span class="badge badge-danger">Time Penalty: {{ $result.PenaltyTime }}</span> {{ end }}
                                 {{ if $result.Disqualified }} <span class="badge badge-danger">Disqualified</span> {{ end }}</td>
                             {{ if $driversHaveTeams }}
@@ -224,15 +224,15 @@
                             {{ end }}
                             <td>{{ prettify $result.CarModel true }}</td>
                             <td>
-                                {{ $bestLap := $sessionResults.GetTime $result.BestLap $result.DriverGUID true }}
+                                {{ $bestLap := $sessionResults.GetTime $result.BestLap $result.DriverGUID $result.CarModel true }}
                                 {{ formatDuration $bestLap true }}<br>
                                 {{ if gt $bestLap 0 }}
                                     <small class="text-muted">Tyre: {{ $result.BestLapTyre $sessionResults }}</small>
                                 {{ end }}
                             </td>
-                            <td>{{ formatDuration ($sessionResults.GetAverageLapTime $result.DriverGUID) true }}</td>
-                            <td>{{ $sessionResults.GetNumLaps $result.DriverGUID }} laps /
-                                {{ $sessionResults.GetCuts $result.DriverGUID }} cuts</td>
+                            <td>{{ formatDuration ($sessionResults.GetAverageLapTime $result.DriverGUID $result.CarModel) true }}</td>
+                            <td>{{ $sessionResults.GetNumLaps $result.DriverGUID $result.CarModel }} laps /
+                                {{ $sessionResults.GetCuts $result.DriverGUID $result.CarModel }} cuts</td>
                             <td>
                                 {{ $hasHandicap := false }}
 

--- a/penalties.go
+++ b/penalties.go
@@ -51,6 +51,7 @@ func (ph *PenaltiesHandler) applyPenalty(r *http.Request) (bool, error) {
 
 	jsonFileName := chi.URLParam(r, "sessionFile")
 	guid := chi.URLParam(r, "driverGUID")
+	carModel := r.URL.Query().Get("model")
 
 	results, err := LoadResult(jsonFileName + ".json")
 
@@ -87,7 +88,7 @@ func (ph *PenaltiesHandler) applyPenalty(r *http.Request) (bool, error) {
 	}
 
 	for _, result := range results.Result {
-		if result.DriverGUID == guid {
+		if result.DriverGUID == guid && result.CarModel == carModel {
 			if remove {
 				result.HasPenalty = false
 				result.Disqualified = false

--- a/penalties.go
+++ b/penalties.go
@@ -112,7 +112,7 @@ func (ph *PenaltiesHandler) applyPenalty(r *http.Request) (bool, error) {
 					result.PenaltyTime = timeParsed
 
 					// If penalty time is greater than a lap then add a lap penalty and change penalty time by one lap
-					lastLapTime := results.GetLastLapTime(result.DriverGUID)
+					lastLapTime := results.GetLastLapTime(result.DriverGUID, result.CarModel)
 
 					if result.PenaltyTime > lastLapTime {
 						result.LapPenalty = int(result.PenaltyTime / lastLapTime)
@@ -138,8 +138,8 @@ func (ph *PenaltiesHandler) applyPenalty(r *http.Request) (bool, error) {
 				}
 
 				// if both drivers are/aren't disqualified
-				return results.GetTime(results.Result[i].BestLap, results.Result[i].DriverGUID, true) <
-					results.GetTime(results.Result[j].BestLap, results.Result[j].DriverGUID, true)
+				return results.GetTime(results.Result[i].BestLap, results.Result[i].DriverGUID, results.Result[i].CarModel, true) <
+					results.GetTime(results.Result[j].BestLap, results.Result[j].DriverGUID, results.Result[j].CarModel, true)
 
 			} else {
 				// driver i is closer to the front than j if they are not disqualified and j is
@@ -152,25 +152,25 @@ func (ph *PenaltiesHandler) applyPenalty(r *http.Request) (bool, error) {
 			if !results.Result[i].Disqualified && !results.Result[j].Disqualified {
 
 				// if both drivers aren't disqualified
-				if results.GetNumLaps(results.Result[i].DriverGUID) == results.GetNumLaps(results.Result[j].DriverGUID) {
+				if results.GetNumLaps(results.Result[i].DriverGUID, results.Result[i].CarModel) == results.GetNumLaps(results.Result[j].DriverGUID, results.Result[j].CarModel) {
 					// if their number of laps are equal, compare lap times
 
-					return results.GetTime(results.Result[i].TotalTime, results.Result[i].DriverGUID, true) <
-						results.GetTime(results.Result[j].TotalTime, results.Result[j].DriverGUID, true)
+					return results.GetTime(results.Result[i].TotalTime, results.Result[i].DriverGUID, results.Result[i].CarModel, true) <
+						results.GetTime(results.Result[j].TotalTime, results.Result[j].DriverGUID, results.Result[j].CarModel, true)
 				}
 
-				return results.GetNumLaps(results.Result[i].DriverGUID) >= results.GetNumLaps(results.Result[j].DriverGUID)
+				return results.GetNumLaps(results.Result[i].DriverGUID, results.Result[i].CarModel) >= results.GetNumLaps(results.Result[j].DriverGUID, results.Result[j].CarModel)
 
 			} else if results.Result[i].Disqualified && results.Result[j].Disqualified {
 
 				// if both drivers ARE disqualified, compare their lap times / num laps
-				if results.GetNumLaps(results.Result[i].DriverGUID) == results.GetNumLaps(results.Result[j].DriverGUID) {
+				if results.GetNumLaps(results.Result[i].DriverGUID, results.Result[i].CarModel) == results.GetNumLaps(results.Result[j].DriverGUID, results.Result[j].CarModel) {
 					// if their number of laps are equal, compare lap times
-					return results.GetTime(results.Result[i].TotalTime, results.Result[i].DriverGUID, true) <
-						results.GetTime(results.Result[j].TotalTime, results.Result[j].DriverGUID, true)
+					return results.GetTime(results.Result[i].TotalTime, results.Result[i].DriverGUID, results.Result[i].CarModel, true) <
+						results.GetTime(results.Result[j].TotalTime, results.Result[j].DriverGUID, results.Result[j].CarModel, true)
 				}
 
-				return results.GetNumLaps(results.Result[i].DriverGUID) >= results.GetNumLaps(results.Result[j].DriverGUID)
+				return results.GetNumLaps(results.Result[i].DriverGUID, results.Result[i].CarModel) >= results.GetNumLaps(results.Result[j].DriverGUID, results.Result[j].CarModel)
 
 			} else {
 				// driver i is closer to the front than j if they are not disqualified and j is

--- a/race_weekend_sort.go
+++ b/race_weekend_sort.go
@@ -197,14 +197,14 @@ func TotalRaceTimeRaceWeekendEntryListSort(rw *RaceWeekend, session *RaceWeekend
 }
 
 func lessTotalEntrantTime(_ *RaceWeekend, _ *RaceWeekendSession, entrantI, entrantJ *RaceWeekendSessionEntrant) bool {
-	if entrantI.SessionResults.GetNumLaps(entrantI.Car.Driver.GUID) == entrantJ.SessionResults.GetNumLaps(entrantJ.Car.Driver.GUID) {
+	if entrantI.SessionResults.GetNumLaps(entrantI.Car.Driver.GUID, entrantI.Car.Model) == entrantJ.SessionResults.GetNumLaps(entrantJ.Car.Driver.GUID, entrantJ.Car.Model) {
 		// drivers have completed the same number of laps, so compare their total time
-		entrantITime := entrantI.SessionResults.GetTime(entrantI.EntrantResult.TotalTime, entrantI.Car.Driver.GUID, true)
-		entrantJTime := entrantJ.SessionResults.GetTime(entrantJ.EntrantResult.TotalTime, entrantJ.Car.Driver.GUID, true)
+		entrantITime := entrantI.SessionResults.GetTime(entrantI.EntrantResult.TotalTime, entrantI.Car.Driver.GUID, entrantI.Car.Model, true)
+		entrantJTime := entrantJ.SessionResults.GetTime(entrantJ.EntrantResult.TotalTime, entrantJ.Car.Driver.GUID, entrantJ.Car.Model, true)
 
 		return entrantITime < entrantJTime
 	} else {
-		return entrantI.SessionResults.GetNumLaps(entrantI.Car.Driver.GUID) > entrantJ.SessionResults.GetNumLaps(entrantJ.Car.Driver.GUID)
+		return entrantI.SessionResults.GetNumLaps(entrantI.Car.Driver.GUID, entrantI.Car.Model) > entrantJ.SessionResults.GetNumLaps(entrantJ.Car.Driver.GUID, entrantJ.Car.Model)
 	}
 }
 
@@ -225,7 +225,7 @@ func lessBestLapTime(_ *RaceWeekend, _ *RaceWeekendSession, entrantI, entrantJ *
 		entrantJCrashes := entrantJ.SessionResults.GetCrashes(entrantJ.Car.Driver.GUID)
 
 		if entrantICrashes == entrantJCrashes {
-			return entrantI.SessionResults.GetCuts(entrantI.Car.Driver.GUID) < entrantJ.SessionResults.GetCuts(entrantJ.Car.Driver.GUID)
+			return entrantI.SessionResults.GetCuts(entrantI.Car.Driver.GUID, entrantI.Car.Model) < entrantJ.SessionResults.GetCuts(entrantJ.Car.Driver.GUID, entrantJ.Car.Model)
 		}
 
 		return entrantICrashes < entrantJCrashes
@@ -257,8 +257,8 @@ func FewestCollisionsRaceWeekendEntryListSort(rw *RaceWeekend, session *RaceWeek
 func FewestCutsRaceWeekendEntryListSort(rw *RaceWeekend, session *RaceWeekendSession, entrants []*RaceWeekendSessionEntrant) error {
 	sort.Slice(entrants, func(i, j int) bool {
 		entrantI, entrantJ := entrants[i], entrants[j]
-		entrantICuts := entrantI.SessionResults.GetCuts(entrantI.Car.Driver.GUID)
-		entrantJCuts := entrantJ.SessionResults.GetCuts(entrantJ.Car.Driver.GUID)
+		entrantICuts := entrantI.SessionResults.GetCuts(entrantI.Car.Driver.GUID, entrantI.Car.Model)
+		entrantJCuts := entrantJ.SessionResults.GetCuts(entrantJ.Car.Driver.GUID, entrantJ.Car.Model)
 
 		if entrantICuts == entrantJCuts {
 			if session.SessionType() == SessionTypeRace {
@@ -279,8 +279,8 @@ func SafetyRaceWeekendEntryListSort(rw *RaceWeekend, session *RaceWeekendSession
 		entrantI, entrantJ := entrants[i], entrants[j]
 		entrantICrashes := entrantI.SessionResults.GetCrashes(entrantI.Car.Driver.GUID)
 		entrantJCrashes := entrantJ.SessionResults.GetCrashes(entrantJ.Car.Driver.GUID)
-		entrantICuts := entrantI.SessionResults.GetCuts(entrantI.Car.Driver.GUID)
-		entrantJCuts := entrantJ.SessionResults.GetCuts(entrantJ.Car.Driver.GUID)
+		entrantICuts := entrantI.SessionResults.GetCuts(entrantI.Car.Driver.GUID, entrantI.Car.Model)
+		entrantJCuts := entrantJ.SessionResults.GetCuts(entrantJ.Car.Driver.GUID, entrantJ.Car.Model)
 
 		if entrantICrashes == entrantJCrashes {
 			if entrantICuts == entrantJCuts {

--- a/results.go
+++ b/results.go
@@ -191,11 +191,11 @@ func (s *SessionResults) GetCrashesOfType(guid, collisionType string) int {
 	return num
 }
 
-func (s *SessionResults) GetAverageLapTime(guid string) time.Duration {
+func (s *SessionResults) GetAverageLapTime(guid, model string) time.Duration {
 	var totalTime, driverLapCount, lapsForAverage, totalTimeForAverage int
 
 	for _, lap := range s.Laps {
-		if lap.DriverGUID == guid {
+		if lap.DriverGUID == guid && lap.CarModel == model {
 			avgSoFar := (float64(totalTime) / float64(lapsForAverage)) * 1.07
 
 			// if lap doesnt cut and if lap is < 107% of average for that driver so far and if lap isn't lap 1
@@ -209,7 +209,7 @@ func (s *SessionResults) GetAverageLapTime(guid string) time.Duration {
 		}
 	}
 
-	return s.GetTime(int(float64(totalTimeForAverage)/float64(lapsForAverage)), guid, false)
+	return s.GetTime(int(float64(totalTimeForAverage)/float64(lapsForAverage)), guid, model, false)
 }
 
 func (s *SessionResults) GetOverallAverageLapTime() time.Duration {
@@ -233,12 +233,12 @@ func (s *SessionResults) GetOverallAverageLapTime() time.Duration {
 	return d
 }
 
-func (s *SessionResults) GetConsistency(guid string) float64 {
+func (s *SessionResults) GetConsistency(guid, model string) float64 {
 	var bestLap int
 
 	for _, lap := range s.Laps {
-		if lap.DriverGUID == guid {
-			if s.IsDriversFastestLap(guid, lap.LapTime, lap.Cuts) {
+		if lap.DriverGUID == guid && lap.CarModel == model {
+			if s.IsDriversFastestLap(guid, model, lap.LapTime, lap.Cuts) {
 				bestLap = lap.LapTime
 			}
 		}
@@ -246,8 +246,8 @@ func (s *SessionResults) GetConsistency(guid string) float64 {
 
 	var percentage float64
 
-	average := s.GetAverageLapTime(guid)
-	best := s.GetTime(bestLap, guid, false)
+	average := s.GetAverageLapTime(guid, model)
+	best := s.GetTime(bestLap, guid, model, false)
 
 	if average != 0 && best != 0 {
 		consistency := average.Seconds() - best.Seconds()
@@ -261,17 +261,17 @@ func (s *SessionResults) GetConsistency(guid string) float64 {
 }
 
 // lapNum is the drivers current lap
-func (s *SessionResults) GetPosForLap(guid string, lapNum int64) int {
+func (s *SessionResults) GetPosForLap(guid, model string, lapNum int64) int {
 	var pos int
 
 	driverLap := make(map[string]int)
 
 	for _, lap := range s.Laps {
-		driverLap[lap.DriverGUID]++
+		driverLap[lap.DriverGUID+lap.CarModel]++
 
-		if driverLap[lap.DriverGUID] == int(lapNum) && lap.DriverGUID == guid {
+		if driverLap[lap.DriverGUID+lap.CarModel] == int(lapNum) && lap.DriverGUID == guid && lap.CarModel == model {
 			return pos + 1
-		} else if driverLap[lap.DriverGUID] == int(lapNum) {
+		} else if driverLap[lap.DriverGUID+lap.CarModel] == int(lapNum) {
 			pos++
 		}
 	}
@@ -296,7 +296,7 @@ func (s *SessionResults) IsFastestLap(time, cuts int) bool {
 	return fastest
 }
 
-func (s *SessionResults) IsDriversFastestLap(guid string, time, cuts int) bool {
+func (s *SessionResults) IsDriversFastestLap(guid, model string, time, cuts int) bool {
 	if cuts != 0 {
 		return false
 	}
@@ -304,7 +304,7 @@ func (s *SessionResults) IsDriversFastestLap(guid string, time, cuts int) bool {
 	fastest := true
 
 	for _, lap := range s.Laps {
-		if lap.LapTime < time && lap.DriverGUID == guid && lap.Cuts == 0 {
+		if lap.LapTime < time && lap.DriverGUID == guid && lap.CarModel == model && lap.Cuts == 0 {
 			fastest = false
 			break
 		}
@@ -342,7 +342,7 @@ func (s *SessionResults) IsFastestSector(sector, time, cuts int) bool {
 	return fastest
 }
 
-func (s *SessionResults) IsDriversFastestSector(guid string, sector, time, cuts int) bool {
+func (s *SessionResults) IsDriversFastestSector(guid, model string, sector, time, cuts int) bool {
 	if cuts != 0 {
 		return false
 	}
@@ -350,7 +350,7 @@ func (s *SessionResults) IsDriversFastestSector(guid string, sector, time, cuts 
 	fastest := true
 
 	for _, lap := range s.Laps {
-		if lap.Sectors[sector] < time && lap.DriverGUID == guid && lap.Cuts == 0 {
+		if lap.Sectors[sector] < time && lap.DriverGUID == guid && lap.CarModel == model && lap.Cuts == 0 {
 			fastest = false
 			break
 		}
@@ -375,7 +375,7 @@ cars:
 		var bestLap int
 
 		for y := range s.Laps {
-			if (s.Cars[i].Driver.GUID == s.Laps[y].DriverGUID) && s.IsDriversFastestLap(s.Cars[i].Driver.GUID, s.Laps[y].LapTime, s.Laps[y].Cuts) {
+			if (s.Cars[i].Driver.GUID == s.Laps[y].DriverGUID) && s.IsDriversFastestLap(s.Cars[i].Driver.GUID, s.Cars[i].Model, s.Laps[y].LapTime, s.Laps[y].Cuts) {
 				bestLap = s.Laps[y].LapTime
 				break
 			}
@@ -424,23 +424,22 @@ cars:
 					return true
 				}
 
-				return s.GetTime(s.Result[i].BestLap, s.Result[i].DriverGUID, true) <
-					s.GetTime(s.Result[j].BestLap, s.Result[j].DriverGUID, true)
+				return s.GetTime(s.Result[i].BestLap, s.Result[i].DriverGUID, s.Result[i].CarModel, true) <
+					s.GetTime(s.Result[j].BestLap, s.Result[j].DriverGUID, s.Result[j].CarModel, true)
 			}
 
 			// if both drivers aren't/are disqualified
-			if s.GetNumLaps(s.Result[i].DriverGUID) == s.GetNumLaps(s.Result[j].DriverGUID) {
+			if s.GetNumLaps(s.Result[i].DriverGUID, s.Result[i].CarModel) == s.GetNumLaps(s.Result[j].DriverGUID, s.Result[j].CarModel) {
 				if s.Result[i].HasPenalty || s.Result[j].HasPenalty {
-					return s.GetTime(s.Result[i].TotalTime, s.Result[i].DriverGUID, true) <
-						s.GetTime(s.Result[j].TotalTime, s.Result[j].DriverGUID, true)
+					return s.GetTime(s.Result[i].TotalTime, s.Result[i].DriverGUID, s.Result[i].CarModel, true) <
+						s.GetTime(s.Result[j].TotalTime, s.Result[j].DriverGUID, s.Result[j].CarModel, true)
 				}
 
 				// if their number of laps are equal, compare last lap pos
-				return s.GetLastLapPos(s.Result[i].DriverGUID) <
-					s.GetLastLapPos(s.Result[j].DriverGUID)
+				return s.GetLastLapPos(s.Result[i].DriverGUID, s.Result[i].CarModel) < s.GetLastLapPos(s.Result[j].DriverGUID, s.Result[j].CarModel)
 			}
 
-			return s.GetNumLaps(s.Result[i].DriverGUID) >= s.GetNumLaps(s.Result[j].DriverGUID)
+			return s.GetNumLaps(s.Result[i].DriverGUID, s.Result[i].CarModel) >= s.GetNumLaps(s.Result[j].DriverGUID, s.Result[j].CarModel)
 
 		} else {
 			// driver i is closer to the front than j if they are not disqualified and j is
@@ -475,8 +474,8 @@ func (s *SessionResults) GetDrivers() string {
 	return strings.Join(drivers, ", ")
 }
 
-func (s *SessionResults) GetTime(timeINT int, driverGUID string, penalty bool) time.Duration {
-	if i := s.GetNumLaps(driverGUID); i == 0 {
+func (s *SessionResults) GetTime(timeINT int, driverGUID, model string, penalty bool) time.Duration {
+	if i := s.GetNumLaps(driverGUID, model); i == 0 {
 		return time.Duration(0)
 	}
 
@@ -484,12 +483,12 @@ func (s *SessionResults) GetTime(timeINT int, driverGUID string, penalty bool) t
 
 	if penalty {
 		for _, driver := range s.Result {
-			if driver.DriverGUID == driverGUID && driver.HasPenalty {
+			if driver.DriverGUID == driverGUID && driver.CarModel == model && driver.HasPenalty {
 				d += driver.PenaltyTime
 
 				switch s.Type {
 				case SessionTypeRace:
-					d -= time.Duration(driver.LapPenalty) * s.GetLastLapTime(driverGUID)
+					d -= time.Duration(driver.LapPenalty) * s.GetLastLapTime(driverGUID, model)
 				}
 			}
 		}
@@ -508,18 +507,18 @@ func (s *SessionResults) GetTeamName(driverGUID string) string {
 	return ""
 }
 
-func (s *SessionResults) GetNumLaps(driverGUID string) int {
+func (s *SessionResults) GetNumLaps(driverGUID, model string) int {
 	var i int
 
 	for _, lap := range s.Laps {
-		if lap.DriverGUID == driverGUID {
+		if lap.DriverGUID == driverGUID && lap.CarModel == model {
 			i++
 		}
 	}
 
 	// Apply lap penalty
 	for _, driver := range s.Result {
-		if driver.DriverGUID == driverGUID && driver.HasPenalty {
+		if driver.DriverGUID == driverGUID && driver.CarModel == model && driver.HasPenalty {
 			i -= driver.LapPenalty
 		}
 	}
@@ -527,9 +526,9 @@ func (s *SessionResults) GetNumLaps(driverGUID string) int {
 	return i
 }
 
-func (s *SessionResults) GetLastLapTime(driverGuid string) time.Duration {
+func (s *SessionResults) GetLastLapTime(driverGuid, model string) time.Duration {
 	for i := len(s.Laps) - 1; i >= 0; i-- {
-		if s.Laps[i].DriverGUID == driverGuid {
+		if s.Laps[i].DriverGUID == driverGuid && s.Laps[i].CarModel == model {
 			return s.Laps[i].GetLapTime()
 		}
 	}
@@ -537,21 +536,21 @@ func (s *SessionResults) GetLastLapTime(driverGuid string) time.Duration {
 	return 1
 }
 
-func (s *SessionResults) GetLastLapPos(driverGuid string) int {
+func (s *SessionResults) GetLastLapPos(driverGuid, model string) int {
 	var driverLaps int
 
 	for i := range s.Laps {
-		if s.Laps[i].DriverGUID == driverGuid {
+		if s.Laps[i].DriverGUID == driverGuid && s.Laps[i].CarModel == model {
 			driverLaps++
 		}
 	}
 
-	return s.GetPosForLap(driverGuid, int64(driverLaps))
+	return s.GetPosForLap(driverGuid, model, int64(driverLaps))
 }
 
-func (s *SessionResults) GetDriverPosition(driverGuid string) int {
+func (s *SessionResults) GetDriverPosition(driverGuid, model string) int {
 	for i := range s.Result {
-		if s.Result[i].DriverGUID == driverGuid {
+		if s.Result[i].DriverGUID == driverGuid && s.Result[i].CarModel == model {
 			return i + 1
 		}
 	}
@@ -559,11 +558,11 @@ func (s *SessionResults) GetDriverPosition(driverGuid string) int {
 	return 0
 }
 
-func (s *SessionResults) GetCuts(driverGuid string) int {
+func (s *SessionResults) GetCuts(driverGuid, model string) int {
 	var i int
 
 	for _, lap := range s.Laps {
-		if lap.DriverGUID == driverGuid {
+		if lap.DriverGUID == driverGuid && lap.CarModel == model {
 			i += lap.Cuts
 		}
 	}


### PR DESCRIPTION
most results functions now require a car model alongside a driver's guid. this is so that if a driver is in a results file N times (in different cars) statistics are correctly reported for each car

fixes #637