### PR TITLE
deprecate run_on_start, add plugins to server options, with more specific separation of executable and arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 v1.6.1
 ------
 
+**Please note, this release deprecates use of "run_on_start" in config.yml. Please read the new config.yml "plugins" section if you were using run_on_start!**
+
 Added:
 
 * Added send chat to driver option to the admin panel on the Live Timings page.
@@ -8,6 +10,7 @@ Added:
 * Added configurable Open Graph images to both the manager as a whole and championships, with these you can link to images that will be shown whenever you share a link of the manager/championship pages on social media (premium).
 * Optimised the handling of UDP messages to improve performance.
 * When using "Any Available Car", one of each car is added to the EntryList (so long as there are enough entrants!) and then after that Entrant cars are randomised.
+* Added a new 'plugins' section to config.yml. Please use this instead of 'run_on_start'. This has been added to fix issues with spaces in plugin path names.
 
 Fixes:
 

--- a/cmd/server-manager/config.example.yml
+++ b/cmd/server-manager/config.example.yml
@@ -219,14 +219,15 @@ server:
   # each executable specified is run from the directory it is inside, for example,
   # the command:
   #
-  # ./my/cool/plugin/path/run.sh --some-opt config.json
+  # /my/cool/plugin/path/run.sh --some-opt config.json
   # now actually performs the following two commands:
   #
-  # 1. cd ./my/cool/plugin/path
+  # 1. cd /my/cool/plugin/path
   # 2. ./run.sh --some-opt config.json
-  run_on_start:
-    # e.g. uncomment the line below to run a 'start.sh' for kissmyrank
-    # - ./assetto/kissmyrank/start.sh
+  plugins:
+    # uncomment the two lines below to run the command '/my/cool/plugin/path/run.sh --some-opt config.json'
+    # - executable: /my/cool/plugin/path/run.sh
+    #  arguments: ["--some-opt", "config.json"]
 
 ################################################################################
 #

--- a/cmd/server-manager/config.example.yml
+++ b/cmd/server-manager/config.example.yml
@@ -227,7 +227,7 @@ server:
   plugins:
     # uncomment the two lines below to run the command '/my/cool/plugin/path/run.sh --some-opt config.json'
     # - executable: /my/cool/plugin/path/run.sh
-    #  arguments: ["--some-opt", "config.json"]
+    #   arguments: ["--some-opt", "config.json"]
 
 ################################################################################
 #

--- a/servermanager_config.go
+++ b/servermanager_config.go
@@ -142,14 +142,14 @@ func (s *StoreConfig) BuildStore() (Store, error) {
 }
 
 type ServerExtraConfig struct {
-	Plugins []*CommandPlugin `yaml:"plugins"`
+	Plugins                     []*CommandPlugin `yaml:"plugins"`
+	AuditLogging                bool             `yaml:"audit_logging"`
+	PerformanceMode             bool             `yaml:"performance_mode"`
+	DisableWindowsBrowserOpen   bool             `yaml:"dont_open_browser"`
+	ScanContentFolderForChanges bool             `yaml:"scan_content_folder_for_changes"`
 
 	// Deprecated; use Plugins instead
-	RunOnStart                  []string `yaml:"run_on_start"`
-	AuditLogging                bool     `yaml:"audit_logging"`
-	PerformanceMode             bool     `yaml:"performance_mode"`
-	DisableWindowsBrowserOpen   bool     `yaml:"dont_open_browser"`
-	ScanContentFolderForChanges bool     `yaml:"scan_content_folder_for_changes"`
+	RunOnStart []string `yaml:"run_on_start"`
 }
 
 type CommandPlugin struct {

--- a/servermanager_config.go
+++ b/servermanager_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cj123/sessions"
 	"github.com/etcd-io/bbolt"
@@ -141,11 +142,26 @@ func (s *StoreConfig) BuildStore() (Store, error) {
 }
 
 type ServerExtraConfig struct {
+	Plugins []*CommandPlugin `yaml:"plugins"`
+
+	// Deprecated; use Plugins instead
 	RunOnStart                  []string `yaml:"run_on_start"`
 	AuditLogging                bool     `yaml:"audit_logging"`
 	PerformanceMode             bool     `yaml:"performance_mode"`
 	DisableWindowsBrowserOpen   bool     `yaml:"dont_open_browser"`
 	ScanContentFolderForChanges bool     `yaml:"scan_content_folder_for_changes"`
+}
+
+type CommandPlugin struct {
+	Executable string   `yaml:"executable"`
+	Arguments  []string `yaml:"arguments"`
+}
+
+func (c *CommandPlugin) String() string {
+	out := c.Executable
+	out += strings.Join(c.Arguments, " ")
+
+	return out
 }
 
 const acsrURL = "https://acsr.assettocorsaservers.com"


### PR DESCRIPTION
(fixes an issue where plugins with spaces in their paths not start)