### PR TITLE
Improving message formatting, issues with download links

### DIFF
--- a/championship_manager_test.go
+++ b/championship_manager_test.go
@@ -142,11 +142,11 @@ func (d dummyNotificationManager) SendRaceStartMessage(config ServerConfig, even
 	return nil
 }
 
-func (d NotificationManager) GetCarList(cars string) string {
+func (d dummyNotificationManager) GetCarList(cars string) string {
 	return "nil"
 }
 
-func (d NotificationManager) GetTrackInfo(track string, layout string, download bool) string {
+func (d dummyNotificationManager) GetTrackInfo(track string, layout string, download bool) string {
 	return "nil"
 }
 

--- a/championship_manager_test.go
+++ b/championship_manager_test.go
@@ -130,16 +130,24 @@ func (d dummyNotificationManager) SendRaceWeekendReminderMessage(raceWeekend *Ra
 	return nil
 }
 
-func (d dummyNotificationManager) SendMessage(msg string) error {
+func (d dummyNotificationManager) SendMessage(title string, msg string) error {
 	return nil
 }
 
-func (d dummyNotificationManager) SendMessageWithLink(msg string, linkText string, link *url.URL) error {
+func (d dummyNotificationManager) SendMessageWithLink(title string, msg string, linkText string, link *url.URL) error {
 	return nil
 }
 
 func (d dummyNotificationManager) SendRaceStartMessage(config ServerConfig, event RaceEvent) error {
 	return nil
+}
+
+func (d NotificationManager) GetCarList(cars string) string {
+	return "nil"
+}
+
+func (d NotificationManager) GetTrackInfo(track string, layout string, download bool) string {
+	return "nil"
 }
 
 func (d dummyNotificationManager) SendRaceScheduledMessage(event *CustomRace, date time.Time) error {

--- a/discord.go
+++ b/discord.go
@@ -310,7 +310,7 @@ func (dm *DiscordManager) Stop() error {
 }
 
 // SendMessage sends a message to the configured channel and logs any errors
-func (dm *DiscordManager) SendMessage(msg string) error {
+func (dm *DiscordManager) SendMessage(title string, msg string) error {
 	if dm.enabled {
 		opts, err := dm.store.LoadServerOptions()
 
@@ -323,15 +323,15 @@ func (dm *DiscordManager) SendMessage(msg string) error {
 		// it in as an arg and check it here anyway
 		if opts.DiscordChannelID != "" {
 			if opts.DiscordRoleID != "" {
-				mention := fmt.Sprintf("Attention <@&%s>\n", opts.DiscordRoleID)
+				mention := fmt.Sprintf("Attention <@&%s> - %s\n", opts.DiscordRoleID, title)
 				messageSend := &discordgo.MessageSend{
 					Content: mention,
-					Embed:   embed.NewGenericEmbed(msg, ""),
+					Embed:   embed.NewEmbed().SetDescription(msg).SetColor(0x1c1c1c).MessageEmbed,
 				}
 				_, err = dm.discord.ChannelMessageSendComplex(opts.DiscordChannelID, messageSend)
 			} else {
 
-				_, err = dm.discord.ChannelMessageSendEmbed(opts.DiscordChannelID, embed.NewGenericEmbed(msg, ""))
+				_, err = dm.discord.ChannelMessageSendEmbed(opts.DiscordChannelID, embed.NewGenericEmbed(title, msg))
 			}
 
 			if err != nil {
@@ -349,7 +349,7 @@ func (dm *DiscordManager) SendMessage(msg string) error {
 }
 
 // SendMessage sends a message to the configured channel and logs any errors
-func (dm *DiscordManager) SendMessageWithLink(msg string, linkText string, link *url.URL) error {
+func (dm *DiscordManager) SendMessageWithLink(title string, msg string, linkText string, link *url.URL) error {
 	if !dm.enabled {
 		return nil
 	}
@@ -367,15 +367,15 @@ func (dm *DiscordManager) SendMessageWithLink(msg string, linkText string, link 
 	// it in as an arg and check it here anyway
 	if opts.DiscordChannelID != "" {
 		if opts.DiscordRoleID != "" {
-			mention := fmt.Sprintf("Attention <@&%s>\n", opts.DiscordRoleID)
+			mention := fmt.Sprintf("Attention <@&%s> - %s\n", opts.DiscordRoleID, title)
 			messageSend := &discordgo.MessageSend{
 				Content: mention,
-				Embed:   embed.NewGenericEmbed(msg, "%s", linkMsg),
+				Embed:   embed.NewEmbed().SetDescription(msg + "\n" + linkMsg).SetColor(0x1c1c1c).MessageEmbed,
 			}
 			_, err = dm.discord.ChannelMessageSendComplex(opts.DiscordChannelID, messageSend)
 		} else {
 
-			_, err = dm.discord.ChannelMessageSendEmbed(opts.DiscordChannelID, embed.NewGenericEmbed(msg, "%s", linkMsg))
+			_, err = dm.discord.ChannelMessageSendEmbed(opts.DiscordChannelID, embed.NewGenericEmbed(title, msg+"\n"+linkMsg))
 		}
 
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/gopherjs/gopherjs v0.0.0-20190309154008-847fc94819f9 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/haisum/recaptcha v0.0.0-20170327142240-7d3b8053900e
+	github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jaytaylor/html2text v0.0.0-20190408195923-01ec452cbe43

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/haisum/recaptcha v0.0.0-20170327142240-7d3b8053900e h1:SLxmrOPIeLANjk9W0BRT9I9w6YAaSTV/RhGAvCfV4io=
 github.com/haisum/recaptcha v0.0.0-20170327142240-7d3b8053900e/go.mod h1:4C2PL8L8RP6rj5QpimHOsQcMh1fecsamFK5aY2V7VBQ=
+github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4 h1:60gBOooTSmNtrqNaRvrDbi8VAne0REaek2agjnITKSw=
+github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=


### PR DESCRIPTION
Separates Discord 'embed' messages into title and message, as you can't have markdown links in the title.  When group tagging notifications are enabled, adds the title to the notification  (the part which shows in the actual notification on phones), like "Attention @notifications - race start in X minutes", rather than just "Attention @notifications".  With notifications disabled, inserts it as the 'title' part of the embed.

Added durafmt library, as it turns out formatting a length of time in human readable format in Go is not trivial.